### PR TITLE
Add support for JSON-stream logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,5 @@ samconfig.toml
 
 config
 .dev
+
+tests/test_data/*

--- a/config/log_processing_rules/vpcdnsquerylogs.yaml
+++ b/config/log_processing_rules/vpcdnsquerylogs.yaml
@@ -12,32 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-name: cwl_to_fh
+name: vpcdnsquerylogs
 known_key_path_pattern: '^.*'
 source: custom
 
 log_format: json_stream
 
-# from the stream of JSON objects, just select the ones with messageType: DATA_MESSAGE
-# (CWL sends CONTROL_MESSAGE messages to check deliverability to Firehose)
-filter_json_objects_key: messageType
-filter_json_objects_value: DATA_MESSAGE
-
-# Within each JSON object in the stream, iterate through logEvents
-log_entries_key: logEvents
-
 annotations:
-  log.source: aws.cloudwatch_logs
+  log.source: aws.vpcdnsquerylogs
   cloud.provider: aws
 
-# From each JSON object within the stream, inherit the below attributes
-attribute_extraction_from_top_level_json:
-  owner: aws.account.id
-  logGroup: aws.cwl.log_group
-  logStream: aws.cwl.log_stream
 
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:
-  timestamp: timestamp
-  content: message
-  aws.cwl.event_id: id
+  timestamp: query_timestamp
+  aws.account.id: account_id
+  aws.region: region
+  aws.vpc_id: vpc_id

--- a/docs/log_forwarding.md
+++ b/docs/log_forwarding.md
@@ -9,7 +9,7 @@ Log Forwarding rules allow you to define custom annotations you may want to add 
 * Network Load Balancer
 * Classic Load Balancer
 
-If you're ingesting other logs, you can just ingest them as `generic` logs and [configure Dynatrace to process the logs](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing) or query them with [DQL](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing/log-processing-commands). If needed, you can also extend the log processing functionality of this solution defining your own log processing rules. For more information, visit the [log_processing](log_processing.md).
+For any other logs you may want to ingest from S3, you can just ingest any text-based logs as `generic` logs (source: generic) and stream of JSON entries logs as `generic_json_stream` (source: generic, source_name: generic_json_stream). Then, you can [configure Dynatrace to process the logs at ingestion time](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing) to enrich them or parse them at query time with [DQL](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing/log-processing-commands). If you need extra-processing done on the Lambda function (e.g. extract log entries from a list in a JSON key), you can also extend the log processing functionality of this solution defining your own log processing rules. For more information, visit the [log_processing](log_processing.md).
 
 ## Configuring log forwarding rules
 

--- a/docs/log_forwarding.md
+++ b/docs/log_forwarding.md
@@ -132,8 +132,7 @@ For each S3 bucket located in a different AWS region, follow the below steps:
 
     **NOTE:** LogBucketPrefix# parameters are optional. If you don't specify any, S3 Object Created notifications will be sent for any object created on the S3 bucket.
 
-1. Once the above stack is deployed, go to your S3 bucket(s) and enable notifications via EventBridge following instructions [here](https://docs.aws.amazon.com/
-AmazonS3/latest/userguide/enable-event-notifications-eventbridge.html).
+1. Once the above stack is deployed, go to your S3 bucket(s) and enable notifications via EventBridge following instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications-eventbridge.html).
 
 1. Last, deploy the `s3-log-forwarder-bucket-config-template.yaml` CloudFormation template on the AWS region where the `dynatrace-aws-s3-log-forwarder` is deployed. This template will deploy the required local Amazon EventBridge rules to send the cross-region forwarded notifications to the S3 forwarder Amazon SQS queue, as well as grant IAM permissions to the AWS Lambda function to access your S3 bucket. If you have defined prefixes on the first step, make sure you specify the same prefixes when deploying this stack.
 

--- a/docs/log_processing.md
+++ b/docs/log_processing.md
@@ -65,7 +65,7 @@ You can ingest any text and JSON-array logs into Dynatrace as generic logs and u
 
     **Processor definition:**
 
-    ```
+    ```bash
     PARSE(content,"INT: version,SPACE,STRING: aws.account.id, SPACE,STRING: aws.eni.interfaceid,SPACE,(IPADDR: srcaddr | STRING),SPACE,(IPADDR: dstaddr|STRING),SPACE,(INT: srcport | STRING),SPACE,(INT: dstport|STRING),SPACE,(INT: protocol|STRING),SPACE,(INT: packets|STRING),SPACE,(INT: bytes|STRING),SPACE,TIMESTAMP('s'): timestamp,SPACE,TIMESTAMP('s'): end_time,SPACE,STRING: action,SPACE,STRING: log_status,EOL")
     ```
 
@@ -109,4 +109,4 @@ ttribute_extraction_from_top_level_json: Optional[dict]  # --> valid only for js
                                                          #     all the log entries
 ```
 
-You can find an example custom processing rule under `config/log_processing_rules/vpcdnsquerylogs.yaml` used to process [VPC DNS Query logs](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html) from AWS. 
+You can find an example custom processing rule under `config/log_processing_rules/vpcdnsquerylogs.yaml` used to process [VPC DNS Query logs](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html) from AWS.

--- a/docs/log_processing.md
+++ b/docs/log_processing.md
@@ -2,26 +2,26 @@
 
 Once a log S3 Object is marked to be forwarded to Dynatrace, its content is then pulled and processed before sending it to Dynatrace according to the defined log processing rules. Log processing rules, define attribute extraction and log enrichment directives.
 
-The `dynatrace-aws-s3-log-forwarder` supports processing plain text and JSON-array logs either gzipped or not. If the log is gzipped, its file extension must be `.gz`. If the log is in JSON format, the file extension must be `.json`.
+The `dynatrace-aws-s3-log-forwarder` supports processing plain text and JSON logs (stream of JSON objects). It's possible to process gzipped logs, but the log file extension must be `.gz`.
 
-For all processed logs, the forwarder enriches the entries with the following attributes:
+For all processed logs, the forwarder enriches the entries with the following contextual attributes:
 
 * `log.source.forwarder`: the Amazon Resource Name (ARN) of the AWS Lambda function that shipped the log to Dynatrace
 * `log.source.s3_bucket_name`: the name of the S3 bucket where the log comes from
 * `log.source.s3_key_name`: the S3 key name the log comes from
 * Any user-defined log attributes defined on the Log Forwarding Rule matched.
 
-There are 3 different kinds of log processing rules:
+The processing rules are grouped into 3 main blocks (aka sources):
 
-* `generic`: Allows you to ingest any JSON or text log. When processed, logs are simply added the above attributes.
-* `aws`: Allows you to ingest supported AWS-vended logs and extract relevant attributes for them. To determine the service vending the log and exact rule to apply, the S3 Key of the log object is matched against the known format. You can find the processing rules on the `src/processing/rules` folder with the details.
+* `generic`: Allows you to ingest any text-formatted or stream of JSON objects log. When processed, logs are simply added the above attributes. You can use [Dynatrace log processing](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing) to do additional processing at ingestion time. For more information, look at the specific [section](log_processing.md#ingesting-logs-as-generic-and-perform-attribute-extraction-with-the-dynatrace-log-processing-pipeline) below.
+* `aws`: Allows you to ingest supported AWS-vended logs and extract relevant attributes for them. To determine the service vending the log and exact rule to apply, the S3 Key of the log object is matched against the known format that AWS uses to deliver the logs. You can find the processing rules on the `src/processing/rules` folder with the details.
 * `custom`: Allows you to ingest logs and apply user-defined processing rules. When using these rules, you also need to define the `source_name` attribute with the name that identifies your custom processing rule on the log_forwarding_rule.
 
 If `aws` or `custom` is defined as source on the log_forwarding_rule and there're no matches against the processed log object, the dynatrace-aws-s3-log-forwarder falls back to the `generic` processing rule.
 
-**NOTE:** If you're ingesting logs using the `generic` processing rule, you can use the Dynatrace [log processing](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing) functionality for attribute extraction.
-
 ## Built-in log processing rules
+
+### AWS-vended logs to Amazon S3
 
 The solution currently supports log processing for:
 
@@ -31,6 +31,13 @@ The solution currently supports log processing for:
 * Amazon Network Load Balancer
 
 The processing rules for these logs are defined in `src/log/processing/rules`.
+
+### Generic log ingestion
+
+The solution provides a set of built-in processing rules for generic ingestion:
+
+* `text`: Reads log entries line by line in text format. To use it, your Log Forwarding Rule need to include `source`: `generic`
+* `json_stream`: Reads a stream of JSON objects, where each object is a log entry. To use it, your Log Forwarding Rule need to include `source`: `generic`, `source_name`: `generic_json_stream`)
 
 ## Ingesting logs as generic and perform attribute extraction with the Dynatrace Log Processing Pipeline
 
@@ -70,19 +77,21 @@ Note that you can also parse log entries directly on your queries without the ne
 
 ## Adding your own log processing rules
 
-If you really need to do log processing on the AWS Lambda function, you can add your own log processing rules under `config/log_processing_rules` (or on a different location defined in the `LOG_PROCESSING_RULES_PATH` environment variable).
+If you really need to do custom log processing on the AWS Lambda function, you can add your own log processing rules under `config/log_processing_rules` (or on a different location defined in the `LOG_PROCESSING_RULES_PATH` environment variable).
 
 A log processing rule has the following format:
 
 ```yaml
-name: Required[str]                   # --> name that uniquely identifies your processing rule
-source: Required[str]                 # --> you'll normally use custom here, but valid values are 'custom', 'aws' and 'generic'
-known_key_path_pattern: Required[str] # --> regular expression matching the file name pattern of your logs. To match anything, use "^.*$"
-log_format: Required[str]             # --> valid values are 'text' or 'json'
-log_entries_key: Optional[str]        # --> if your log is JSON and the entries are under a List inside the document, 
-                                      #     put here the name of the JSON key containing the list of log entries. 
-annotations: Optional[dict]           # --> key/value attributes to add to all log entries (e.g. log.source: nginx)
-requester: Optional[List[str]]        # --> expected AWS Account ID pushing the logs (this field is not currently used, and it's for future se)
+name: Required[str]                       # --> name that uniquely identifies your processing rule
+source: Required[str]                     # --> you'll normally use custom here, but valid values are 'custom', 'aws' and 'generic'
+known_key_path_pattern: Required[str]     # --> regular expression matching the file name pattern of your logs. To match anything, use "^.*$"
+log_format: Required[str]                 # --> valid values are 'text' (UTF-8) or 'json' (Array of JSON objects) or 'json_stream' (set of JSON objects)
+filter_json_objects_key: Optional[str]    # --> valid only for json_stream processing. Filters log JSON objects with the specified key (value is mandatory if a key is specified)
+filter_json_objects_value: Optional[str]  # --> valid only for json_stream processing. Filters log JSON objects with the specified value for the above key. 
+log_entries_key: Optional[str]            # --> if your log is json or json_stream format and the entries are under a List inside a Key, 
+                                          #     put here the name of the JSON key containing the list of log entries. 
+annotations: Optional[dict]               # --> key/value attributes to add to all log entries (e.g. log.source: nginx)
+requester: Optional[List[str]]            # --> expected AWS Account ID pushing the logs (this field is not currently used, and it's for future se)
 attribute_extraction_from_key_name: Optional[dict]       # --> attribute_name: regular expression to apply to the S3 Key Name 
                                                          #     to extract an attribute. You can use pre-defined regular expressions 
                                                          #     in src/utils/helpers (e.g. {aws_account_id_pattern}, {aws_region_pattern})
@@ -96,4 +105,8 @@ attribute_extraction_jmespath_expression: Optional[dict] # --> JMESPATH expressi
                                                          #     Example to map the 'eventTime' value in a JSON log, to 'timestamp' 
                                                          #     (recognized field in Dynatrace for event timestamp):
                                                          #       - timestamp: eventTime 
+ttribute_extraction_from_top_level_json: Optional[dict]  # --> valid only for json_stream processing with array of log entries inside. Adds as attributes the defined JSON keys to 
+                                                         #     all the log entries
 ```
+
+You can find an example custom processing rule under `config/log_processing_rules/vpcdnsquerylogs.yaml` used to process [VPC DNS Query logs](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html) from AWS. 

--- a/src/log/forwarding/log_forwarding_rule.py
+++ b/src/log/forwarding/log_forwarding_rule.py
@@ -46,15 +46,17 @@ class LogForwardingRule:
             if not isinstance(i,str):
                 raise ValueError(f"{i} is not a str.")
         
-        if self.source != "custom" and self.source_name is not None:
-            raise ValueError("Source name must be 'None' for non custom sources.")
+        if self.source == "aws" and self.source_name is not None:
+            raise ValueError("Source name must be 'None' for aws sources.")
         elif self.source == 'custom' and self.source_name is None:
             raise ValueError("source_name requires a value when source is 'custom'")
 
     def __post_init__(self):
-        self.validate()
         if self.sinks is None:
             object.__setattr__(self,"sinks",["1"])
+        if self.source == "generic" and self.source_name is None:
+            object.__setattr__(self,"source_name","generic")
+        self.validate()
 
 
     def match(self, key_name):

--- a/src/log/processing/log_processing_rules.py
+++ b/src/log/processing/log_processing_rules.py
@@ -53,7 +53,8 @@ def create_log_processing_rule(rule_dict):
     required_attributes = ['name', 'source','known_key_path_pattern', 'log_format']
     optional_attributes = ['log_entries_key', 'annotations','requester',
                            'attribute_extraction_from_key_name', 'attribute_extraction_grok_expression',
-                           'attribute_extraction_jmespath_expression']
+                           'attribute_extraction_jmespath_expression', 'filter_json_objects_key',
+                           'filter_json_objects_value','attribute_extraction_from_top_level_json']
 
     for attribute in required_attributes:
         if attribute not in rule_dict.keys():
@@ -65,16 +66,19 @@ def create_log_processing_rule(rule_dict):
 
     try:
         processing_rule = LogProcessingRule(
-            rule_dict['name'],
-            rule_dict['source'],
-            rule_dict['known_key_path_pattern'],
-            rule_dict['log_format'],
-            rule_dict['log_entries_key'],
-            rule_dict['annotations'],
-            rule_dict['requester'],
-            rule_dict['attribute_extraction_from_key_name'],
-            rule_dict['attribute_extraction_grok_expression'],
-            rule_dict['attribute_extraction_jmespath_expression']
+            name= rule_dict['name'],
+            source = rule_dict['source'],
+            known_key_path_pattern = rule_dict['known_key_path_pattern'],
+            log_format = rule_dict['log_format'],
+            filter_json_objects_key = rule_dict['filter_json_objects_key'],
+            filter_json_objects_value = rule_dict['filter_json_objects_value'],
+            log_entries_key = rule_dict['log_entries_key'],
+            annotations = rule_dict['annotations'],
+            requester = rule_dict['requester'],
+            attribute_extraction_from_key_name = rule_dict['attribute_extraction_from_key_name'],
+            attribute_extraction_grok_expression = rule_dict['attribute_extraction_grok_expression'],
+            attribute_extraction_jmespath_expression = rule_dict['attribute_extraction_jmespath_expression'],
+            attribute_extraction_from_top_level_json = rule_dict['attribute_extraction_from_top_level_json']
         )
     except ValueError as e:
         raise InvalidLogProcessingRuleFile("Error parsing processing rule.")
@@ -105,7 +109,7 @@ def load_rules_from_dir(directory: str) -> dict:
                 # Check that source on the rule is valid. (custom is custom.name)
                 source = processing_rule_dict['source'].split('.')[0]
                 if source not in AVAILABLE_LOG_SOURCES:
-                    raise InvalidLogProcessingRuleFile(file=rule_file,message="Invalid log source on rule file.")
+                    raise InvalidLogProcessingRuleFile(file=rule_file.name,message="Invalid log source on rule file.")
 
                 log_processing_rules[source][processing_rule_dict['name']] = create_log_processing_rule(processing_rule_dict)
 
@@ -119,6 +123,9 @@ class InvalidLogProcessingRuleFile(Exception):
     def __init__(self, file=None, message='Processing rule file is invalid.'):
         self.file = file
         self.message = message
+
+    def __str__(self):
+        return f"{self.message} --> {self.file}"
 
     
 def load_built_in_rules():

--- a/src/log/processing/log_processing_rules.py
+++ b/src/log/processing/log_processing_rules.py
@@ -194,13 +194,11 @@ def lookup_processing_rule(source: str , source_name: str, processing_rules: dic
     
     if not source in AVAILABLE_LOG_SOURCES or source is None:
         return None
-    elif source == 'generic':
-        return processing_rules['generic']['generic']
-    # is it a custom rule? (e.g. custom.nginx)
-    elif source == 'custom':
+    # is it a generic or custom rule? 
+    elif source == 'custom' or source == 'generic':
         try:
             logger.debug(f'Matched log processing rule {source}.{source_name}')
-            return processing_rules['custom'][source_name]
+            return processing_rules[source][source_name]
         except KeyError:
             logger.warning(f"No matching log processing rule for {source}.{source_name}."
                             "Defaulting to 'generic' log ingestion.")

--- a/src/log/processing/rules/custom/cwl-to-fh.yaml
+++ b/src/log/processing/rules/custom/cwl-to-fh.yaml
@@ -1,0 +1,43 @@
+# Copyright 2022 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: cwl_to_fh
+known_key_path_pattern: '^.*'
+source: custom
+
+log_format: json_stream
+
+# from the stream of JSON objects, just select the ones with messageType: DATA_MESSAGE
+# (CWL sends CONTROL_MESSAGE messages to check deliverability to Firehose)
+filter_json_objects_key: messageType
+filter_json_objects_value: DATA_MESSAGE
+
+# Within each JSON object in the stream, iterate through logEvents
+log_entries_key: logEvents
+
+annotations:
+  log.source: aws.cloudwatch_logs
+  cloud.provider: aws
+
+# From each JSON object within the stream, inherit the below attributes
+attribute_extraction_from_top_level_json:
+  owner: aws.account.id
+  logGroup: aws.cwl.log_group
+  logStream: aws.cwl.log_stream
+
+# map message keys to DT LogsV2 API format  
+attribute_extraction_jmespath_expression:
+  timestamp: timestamp
+  content: message
+  aws.cwl.id: id

--- a/src/log/processing/rules/generic_json_stream.yaml
+++ b/src/log/processing/rules/generic_json_stream.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# default rule for generic logs
+name: generic_json_stream
+
+# match anything
+known_key_path_pattern: '^.*$'
+
+source: generic
+
+log_format: json_stream

--- a/src/log/processing/rules/generic_json_stream.yaml
+++ b/src/log/processing/rules/generic_json_stream.yaml
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# default rule for generic logs
+# default rule for generic JSON-stream logs
 name: generic_json_stream
 
 # match anything


### PR DESCRIPTION
* Adds functionality to ingest JSON-stream logs, addressing #2. A new generic_json_stream forwarding rule has been added for this.
* Update docs with the new functionality.
* Add a custom rule to allow log ingestion of AWS Services writing logs to CloudWatch Logs via Firehose delivery to Amazon S3.