### PR TITLE
Add new AWS log processing rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,9 +102,6 @@ jobs:
     
     after_script: 
       - ./tests/e2e/clean_up_resources.sh
-    
-    after_failure: 
-      - ./tests/e2e/clean_up_resources.sh
   
   - stage: release-container-image
     name: Release Container Image

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ To deploy the `dynatrace-aws-s3-log-forwarder` using the provided container imag
     export DYNATRACE_TENANT_UUID=replace_with_your_dynatrace_tenant_uuid
     ```
 
-    **IMPORTANT:** Your stack name should have a maximum of 54 characters, otherwise deployment will fail.
+    > **Important**
+    > Your stack name should have a maximum of 54 characters, otherwise deployment will fail.
 
 1. Create an AWS SSM SecureString Parameter to store your Dynatrace access token to ingest logs.
 
@@ -51,10 +52,11 @@ To deploy the `dynatrace-aws-s3-log-forwarder` using the provided container imag
      aws ssm put-parameter --name $PARAMETER_NAME --type SecureString --value $PARAMETER_VALUE
     ```
 
-    **NOTES:**
-    * HISTCONTROL is set here to avoid storing commands starting with a space on bash history.
-    * It's important that your parameter name follows the structure above, as the solution grants permissions to AWS Lambda to the hierarchy `/dynatrace/s3-log-forwarder/your_stack_name/*`
-    * Your API Key is stored encyrpted with the default AWS-managed key alias: `aws/ssm`. If you want to use a Customer-managed Key, you'll need to grant Decrypt permissions to the AWS Lambda IAM Role that's deployed within the CloudFormation template.
+    > **Notes**
+    >
+    > * HISTCONTROL is set here to avoid storing commands starting with a space on bash history.
+    > * It's important that your parameter name follows the structure above, as the solution grants permissions to AWS Lambda to the hierarchy `/dynatrace/s3-log-forwarder/ your_stack_name/*`
+    > * Your API Key is stored encyrpted with the default AWS-managed key alias: `aws/ssm`. If you want to use a Customer-managed Key, you'll need to grant Decrypt permissions > to the AWS Lambda IAM Role that's deployed within the CloudFormation template.
 
 1. Create an Amazon ECR repository on your AWS account.
 
@@ -97,18 +99,18 @@ To deploy the `dynatrace-aws-s3-log-forwarder` using the provided container imag
                 --template-file template.yaml --capabilities CAPABILITY_IAM 
     ```
 
-    **NOTEs:**
-
-    * You can optionally configure notifications on your e-mail address to receive alerts when log files can't be processed and messages are arriving to the Dead Letter Queue. To do so, add the parameter `NotificationsEmail`=`your_email_address_here`.
-    * An Amazon SNS topic is created to receive monitoring alerts where you can subscribe HTTP endpoints to send the notification to your tools (e.g. PagerDuty, Service Now...).
-    * If you plan to forward logs from Amazon S3 buckets in different AWS accounts and regions that where you're deploying the log forwarder, add the parmeters `EnableCrossRegionCrossAccountForwarding`=`true` and optionally `AwsAccountsToReceiveLogsFrom`=`012345678912,987654321098` to the above command. (You can enable this at a later stage, re-running the command above with the mentioned parameters). For more detailed information look at the [docs/log_forwarding](docs/log_forwarding.md#forward-logs-from-s3-buckets-on-different-aws-regions) documentation.
-    * The template is deployed with a pre-defined set of default values to suit the majority of use cases. If you want to customize deployment values, you can find the parameter descriptions on the [template.yaml](template.yaml#L29-L135) file. You'll find more information on the [docs/advanced_deployments](docs/advanced_deployments.md) documentation.
-
     If successfull, you'll see the a message similar to the below at the end of the execution:
 
     ```bash
     Successfully created/updated stack - dynatrace-s3-log-forwarder in us-east-1
     ```
+
+    > **Notes**
+    >
+    > * You can optionally configure notifications on your e-mail address to receive alerts when log files can't be processed and messages are arriving to the Dead Letter Queue. To do so, add the parameter `NotificationsEmail`=`your_email_address_here`.
+    > * An Amazon SNS topic is created to receive monitoring alerts where you can subscribe HTTP endpoints to send the notification to your tools (e.g. PagerDuty, Service  Now...).
+    > * If you plan to forward logs from Amazon S3 buckets in different AWS accounts and regions that where you're deploying the log forwarder, add the parmeters `EnableCrossRegionCrossAccountForwarding`=`true` and optionally `AwsAccountsToReceiveLogsFrom`=`012345678912,987654321098` to the above command. (You can enable this at a later stage, re-running the command above with the mentioned parameters). For more detailed information look at the [docs/log_forwarding](docs/log_forwarding. md#forward-logs-from-s3-buckets-on-different-aws-regions) documentation.
+    > * The template is deployed with a pre-defined set of default values to suit the majority of use cases. If you want to customize deployment values, you can find the parameter descriptions on the [template.yaml](template.yaml#L29-L135) file. You'll find more information on the [docs/advanced_deployments](docs/advanced_deployments.md) documentation.
 
 1. The log forwarding Lambda function pulls configuration data from AWS AppConfig that contains the rules that defines how to forward and process log files. The `dynatrace-aws-s3-log-forwarder-configuration.yaml` CloudFormation template is designed to help get you started deploying the log forwarding configuration. It deploys a default "catch all" log forwarding rule that makes the log forwarding Lambda function process any S3 Object it receives an S3 Object Created notification for, and attempts to identify the source of the log, matching the object against supported AWS log sources. The log forwarder logic falls back to generic text log ingestion if it's unable to identify the log source:
 
@@ -134,9 +136,10 @@ To deploy the `dynatrace-aws-s3-log-forwarder` using the provided container imag
         --parameter-overrides DynatraceAwsS3LogForwarderStackName=$STACK_NAME
     ```
 
-    **NOTES:**
-    * You can deploy updated configurations at any point in time, the log forwarding function will load them in ~1 minute after they've been deployed.
-    * The log forwarder adds context attributes to all forwarded logs, including: `log.source.aws.s3.bucket.name`, `log.source.aws.s3.key.name` and `cloud.forwarder`. Additional attributes are extracted from log contents for supported AWS-vended logs.
+    > **Notes**
+    >
+    > * You can deploy updated configurations at any point in time, the log forwarding function will load them in ~1 minute after they've been deployed.
+    > * The log forwarder adds context attributes to all forwarded logs, including: `log.source.aws.s3.bucket.name`, `log.source.aws.s3.key.name` and `cloud.forwarder`. Additional attributes are extracted from log contents for supported AWS-vended logs.
 
 1. At this point, you have successfully deployed the `dynatrace-aws-s3-log-forwarder` with your desired configuration. Now, you need to configure specific Amazon S3 buckets to send "S3 Object created" notifications to the log forwarder; as well as grant permissions to the log forwarder to read files from your bucket. For each bucket that you want to send logs from to Dynatrace, perform the below steps:
 
@@ -154,9 +157,15 @@ To deploy the `dynatrace-aws-s3-log-forwarder` using the provided container imag
             --capabilities CAPABILITY_IAM
         ```
 
-        **NOTES:**
-        * The S3 bucket must be on the same AWS account and region than where your log forwarder is deployed. For cross-region and cross-account deployments, check the [docs/log_forwarding.md](docs/log_forwarding.md#forward-logs-from-s3-buckets-on-different-aws-regions) docs.
-        * If you want to forward logs only for specific S3 prefixes, you can add up to 10 LogsBucketPrefix# parameter overrides (e.g. LogsBucketPrefix1=dev/ LogsBucketPrefix2=prod/ ...)
+        > **Notes**
+        >
+        > * The S3 bucket must be on the same AWS account and region than where your log forwarder is deployed. For cross-region and cross-account deployments, check the [docs/log_forwarding.md](docs/log_forwarding.md#forward-logs-from-s3-buckets-on-different-aws-regions) docs.
+        > * If you want to forward logs only for specific S3 prefixes, you can add up to 10 LogsBucketPrefix# parameter overrides (e.g. LogsBucketPrefix1=dev/ LogsBucketPrefix2=prod/ ...)
+        > * If your logs on S3 are SSE-KMS encrypted with a customer-managed KMS key, you need to grant `kms:Decrypt` permissions to the IAM role used by the AWS Lambda function forwarding logs so it can download the logs. You can find the IAM role name on the CloudFormation outputs of the log forwarder stack. For more information, check the AWS KMS [documentation](https://docs.aws.amazon.com/kms/latest/developerguide/control-access.html).
+        >
+        >    ```bash
+        >    aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[].Outputs[?OutputKey==`QueueProcessingFunctionIamRole`].OutputValue' --output text
+        >    ```
 
 ### Next steps
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ This project deploys a Serverless architecture to forward logs from Amazon S3 to
 
 ![Architecture](docs/images/architecture.jpg)
 
+## Supported AWS Services
+
+The `dynatrace-aws-s3-log-forwarder` supports out-of-the-box parsing and forwarding of logs for the following AWS Services:
+
+* AWS Elastic Load Balancing access logs ([ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html), [NLB](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html) and [Classic ELB](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/access-log-collection.html))
+* [Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html) access logs
+* [AWS CloudTrail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-examples.html) logs
+* [AWS Global Accelerator](https://docs.aws.amazon.com/global-accelerator/latest/dg/monitoring-global-accelerator.flow-logs.html) Flow logs
+* [Amazon Managed Streaming for Kafka](https://docs.aws.amazon.com/msk/latest/developerguide/msk-logging.html) logs
+* [AWS Network Firewall](https://docs.aws.amazon.com/network-firewall/latest/developerguide/logging-s3.html) alert and flow logs
+* [Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-manage-log-files) audit logs
+* [Amazon S3 access logs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html)
+* [Amazon VPC DNS query logs](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html)
+* [Amazon VPC Flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html) (default logs)
+* [AWS WAF](https://docs.aws.amazon.com/waf/latest/developerguide/logging-s3.html) logs
+
+Additionally, you can ingest any generic text and JSON logs. For more information, visit [docs/log_forwarding.md](docs/log_forwarding.md).
+
 ## Deployment instructions
 
 ### Prerequisites

--- a/docs/log_forwarding.md
+++ b/docs/log_forwarding.md
@@ -57,12 +57,7 @@ Log forwarding rules allow you to add custom annotations to your logs (e.g team:
 * log.source.aws.s3.key.name: key name of the S3 object that the log entry belongs to
 * cloud.log_forwarder: the ARN of the AWS Lambda function that forwarded the log entry (this helps if you have multiple log forwarding instances running)
 
-The `dynatrace-aws-s3-log-forwarder` automatically annotates logs and extracts relevant attributes for supported AWS services with fields like `aws.account.id`, `aws.region`... The following AWS-vended logs are supported:
-
-* CloudTrail
-* Application Load Balancer
-* Network Load Balancer
-* Classic Load Balancer
+The `dynatrace-aws-s3-log-forwarder` automatically annotates logs and extracts relevant attributes for [supported AWS services](../README.md#supported-aws-services) with fields like `aws.account.id`, `aws.region`...
 
 For any other logs you may want to ingest from S3, you can just ingest any text-based logs as `generic` logs (source: generic) and stream of JSON entries logs as `generic_json_stream` (source: generic, source_name: generic_json_stream). Then, you can [configure Dynatrace to process the logs at ingestion time](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing) to enrich them or parse them at query time with [DQL](https://www.dynatrace.com/support/help/how-to-use-dynatrace/log-monitoring/acquire-log-data/log-processing/log-processing-commands). Optionally, you can do custom processing on the Lambda function (e.g. extract log entries from a list in a JSON key) defining your own log processing rules. For more information, visit the [log_processing](log_processing.md) documentation.
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar-python.version=3.9

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar-python.version=3.9

--- a/src/app.py
+++ b/src/app.py
@@ -24,6 +24,7 @@ from log.processing import processing
 from log.forwarding import log_forwarding_rules
 from log.sinks import dynatrace
 from utils import aws_appconfig_extension_helpers as aws_appconfig_helpers
+from version import get_version
 
 
 logger = logging.getLogger()
@@ -94,6 +95,8 @@ def reload_rules(rules_type: str):
 
 @metrics.log_metrics
 def lambda_handler(event, context):
+
+    logging.info("dynatrace-aws-s3-log-forwarder version: %s", get_version())
 
     # If we're using AWS AppConfig and there's a new config version available, reload
     reload_rules('forwarding')
@@ -174,7 +177,7 @@ def lambda_handler(event, context):
                     continue
 
                 processing.process_log_object(
-                    matched_log_processing_rule, bucket_name, key_name,
+                    matched_log_processing_rule, bucket_name, key_name, s3_notification['region'],
                     log_object_destination_sinks, context,
                     user_defined_annotations=user_defined_log_annotations,
                     session=boto3_session

--- a/src/log/processing/log_processing_rule.py
+++ b/src/log/processing/log_processing_rule.py
@@ -213,7 +213,7 @@ class LogProcessingRule:
             attributes_dict.pop('timestamp_to_transform')
         
         # Check if aws.log_group exists to extract aws.service and aws.resource.id
-        if "aws.log_group" and "aws.log_stream" in json_message:
+        if "aws.log_group" in json_message and "aws.log_stream" in json_message:
             attributes_dict.update(get_attributes_from_cloudwatch_logs_data(
                 json_message['aws.log_group'], json_message['aws.log_stream']
             ))

--- a/src/log/processing/log_processing_rule.py
+++ b/src/log/processing/log_processing_rule.py
@@ -178,8 +178,11 @@ class LogProcessingRule:
                 jmespath_attr = jmespath.search(v, json_message)
                 if jmespath_attr is not None:
                     attributes_dict[k] = jmespath_attr
-                    # if attribute is being renamed, remove (pygrok fails when keys contain '.')
-                    attributes_dict.pop(v,'')
+                    # if attribute is being renamed from existing attribute remove
+                    # but consider the case when an attribute is being extracted from json with the same name for mapping
+                    # e.g timestamp extraction
+                    if k != v:
+                        attributes_dict.pop(v,'')
                 else:
                     logger.warning('No matches for JMESPATH expression %s', v)
 
@@ -219,7 +222,7 @@ class LogProcessingRule:
 
         attributes.update(self.get_attributes_from_s3_key_name(s3_key_name))
         attributes.update(self.get_extracted_log_attributes(message))
-        attributes.update(self.get_processing_log_annotations)
+        attributes.update(self.get_processing_log_annotations())
 
         return attributes
 

--- a/src/log/processing/log_processing_rule.py
+++ b/src/log/processing/log_processing_rule.py
@@ -96,10 +96,9 @@ class LogProcessingRule:
                 "attribute_extraction_from_top_level_json is only valid for JSON Stream with JSON list entries")
 
         # validate filter json key-value if not None
-        if self.filter_json_objects_key:
-            if not self.filter_json_objects_value:
-                raise ValueError(
-                    "filter_json_objects_value can't be None if filter_json_objects_key is specified")
+        if self.filter_json_objects_key and not self.filter_json_objects_value:
+            raise ValueError(
+                "filter_json_objects_value can't be None if filter_json_objects_key is specified")
 
         # validate optional lists
         if not (isinstance(self.requester, list) or self.requester is None):

--- a/src/log/processing/log_processing_rule.py
+++ b/src/log/processing/log_processing_rule.py
@@ -27,7 +27,19 @@ def parse_date_from_string(date_string: str):
     '''
     Uses dateutil to parse a date from a given str
     '''
-    return dateparser.parse(date_string,fuzzy=True).isoformat()
+    datetime = date_string
+
+    try:
+        datetime = dateparser.parse(date_string,fuzzy=True).isoformat()
+    except dateparser.ParserError:
+        # Redshift timestamp doesn't include timezone, but logs are UTC. Example:
+        # authenticated |Tue, 21 Feb 2023 16:58:20:471|[local]
+        try:
+            datetime = dateparser.parse(date_string + "Z",fuzzy=True).isoformat()
+        except dateparser.ParserError:
+            logger.exception("Unable to convert string timestamp")
+
+    return datetime
 
 @dataclass(frozen=True)
 class LogProcessingRule:

--- a/src/log/processing/log_processing_rules.py
+++ b/src/log/processing/log_processing_rules.py
@@ -296,7 +296,7 @@ def lookup_processing_rule(source: str, source_name: str, processing_rules: dict
     source_name is only used for 'custom' rules.
     '''
 
-    if not source in AVAILABLE_LOG_SOURCES or source is None:
+    if source not in AVAILABLE_LOG_SOURCES or source is None:
         return None
     # is it a generic or custom rule?
     elif source == 'custom' or source == 'generic':

--- a/src/log/processing/log_processing_rules.py
+++ b/src/log/processing/log_processing_rules.py
@@ -229,6 +229,7 @@ def load_custom_rules():
     If custom rules are local, version is set to 0.
     '''
     log_processing_rules_verison = 0
+    log_processing_rules = {}
 
     if os.environ.get('LOG_FORWARDER_CONFIGURATION_LOCATION') == 'aws-appconfig':
         log_processing_rules, log_processing_rules_verison = load_custom_rules_from_aws_appconfig()

--- a/src/log/processing/log_processing_rules.py
+++ b/src/log/processing/log_processing_rules.py
@@ -61,11 +61,11 @@ def create_log_processing_rule(rule_dict):
                            'filter_json_objects_value', 'attribute_extraction_from_top_level_json']
 
     for attribute in required_attributes:
-        if attribute not in rule_dict.keys():
+        if attribute not in rule_dict:
             raise InvalidLogProcessingRuleFile
 
     for attribute in optional_attributes:
-        if attribute not in rule_dict.keys():
+        if attribute not in rule_dict:
             rule_dict[attribute] = None
 
     # Check that source on the rule is valid. (
@@ -153,6 +153,8 @@ def load_processing_rules_from_yaml(body: str):
                 if isinstance(processing_rule_dict, dict):
                     log_processing_rules[processing_rule_dict['source']][processing_rule_dict['name']
                                                                          ] = create_log_processing_rule(processing_rule_dict)
+                    logger.info("Loaded custom log_processing-rule: %s",log_processing_rules[processing_rule_dict['source']
+                                                        ][processing_rule_dict['name']])
                 elif processing_rule_dict is None:
                     logger.warning("Skipping empty log processing rule")
                 else:

--- a/src/log/processing/log_processing_rules.py
+++ b/src/log/processing/log_processing_rules.py
@@ -89,7 +89,8 @@ def create_log_processing_rule(rule_dict):
             attribute_extraction_jmespath_expression=rule_dict[
                 'attribute_extraction_jmespath_expression'],
             attribute_extraction_from_top_level_json=rule_dict[
-                'attribute_extraction_from_top_level_json']
+                'attribute_extraction_from_top_level_json'],
+            skip_header_lines=rule_dict.get('skip_header_lines',0)
         )
     except ValueError as ex:
         raise InvalidLogProcessingRuleFile(

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -204,6 +204,10 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
 
         # if log is text, json list or json stream
         elif log_processing_rule.log_format == 'text':
+            # check if we need to skip header lines
+            if num_log_entries+1 <= log_processing_rule.skip_header_lines:
+                num_log_entries +=1
+                continue
             if isinstance(log_entry, bytes):
                 log_entry = log_entry.decode(ENCODING)
                 if log_entry == '':

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -168,13 +168,13 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
                     dt_log_message = {}
                     dt_log_message['content'] = json.dumps(sub_entry)
 
+                    dt_log_message.update(context_log_attributes)
                     dt_log_message.update(top_level_json_attributes)
 
                     # add cwl attributes to subentry for additional extraction
                     sub_entry.update(top_level_json_attributes)
                     dt_log_message.update(
                         log_processing_rule.get_extracted_log_attributes(sub_entry))
-                    dt_log_message.update(context_log_attributes)
 
                     # if the aws.region is not found, infer region from bucket
                     if "aws.region" not in dt_log_message:

--- a/src/log/processing/rules/aws/alb.yaml
+++ b/src/log/processing/rules/aws/alb.yaml
@@ -18,7 +18,7 @@ name: ALB
  # Prefix:[/prefix]/AWSLogs/aws-account-id/elasticloadbalancing/region/yyyy/mm/dd/aws-account-id_elasticloadbalancing_region
  # File Name: aws-account-id_elasticloadbalancing_region_app.load-balancer-id_end-time_ip-address_random-string.log.gz
  # Random string is 8 chars?
-known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(elasticloadbalancing)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(elasticloadbalancing)_{aws_region_pattern}_(app.){elbv2_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_{ipv4_address_pattern}_[a-zA-Z0-9]{{8}}(.log.gz)$'
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(elasticloadbalancing)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(elasticloadbalancing)_{aws_region_pattern}_(app.){elbv2_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_{ipv4_address_pattern}_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
 
 source: aws
 

--- a/src/log/processing/rules/aws/alb.yaml
+++ b/src/log/processing/rules/aws/alb.yaml
@@ -64,3 +64,4 @@ attribute_extraction_grok_expression: '%{DATA:request_type} %{TIMESTAMP_ISO8601:
 
 attribute_extraction_jmespath_expression:
   severity: "((elb_status_code.to_number(@) >= `400` && elb_status_code.to_number(@) < `500`) && 'WARN') || (elb_status_code.to_number(@) >= `500` && 'ERROR') || 'INFO'"
+  aws.resource.id: elbv2_id

--- a/src/log/processing/rules/aws/classic-elb.yaml
+++ b/src/log/processing/rules/aws/classic-elb.yaml
@@ -60,3 +60,4 @@ attribute_extraction_grok_expression: "%{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE
 
 attribute_extraction_jmespath_expression:
    severity: "((elb_status_code.to_number(@) >= `400` && elb_status_code.to_number(@) < `500`) && 'WARN') || (elb_status_code.to_number(@) >= `500` && 'ERROR') || 'INFO'"
+   aws.resource.id: elb

--- a/src/log/processing/rules/aws/cloudfront.yaml
+++ b/src/log/processing/rules/aws/cloudfront.yaml
@@ -1,0 +1,36 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: cloudfront
+
+# File Name format:  <optional prefix>/<distribution ID>.YYYY-MM-DD-HH.unique-ID.gz
+# File Name example: example/E1SFLUZKKLSP61.2023-02-16-14.e519cdee.gz
+# Random string is 11 uppercase chars?
+known_key_path_pattern: '^.*?{cloudfront_distribution_id_pattern}\.{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}\.[a-fA-F0-9]{{8}}\.gz$'
+
+source: aws
+
+log_format: text
+
+annotations:
+  cloud.provider: aws
+  aws.service: cloudfront
+  aws.region: global
+
+attribute_extraction_from_key_name:
+  aws.resource.id: '{cloudfront_distribution_id_pattern}(?=\.{year_pattern}-{month_pattern}-{day_pattern})'
+
+attribute_extraction_grok_expression: "%{CLOUDFRONTTIMESTAMP:timestamp_to_transform}"
+
+skip_header_lines: 2

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -22,7 +22,6 @@ log_format: json
 log_entries_key: Records
 
 annotations:
-  log.source: aws.cloudtrail
   cloud.provider: aws
   aws.service: cloudtrail
 

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -15,7 +15,7 @@
 name: CloudTrail
 # Prefix: <optional_prefix>/AWSLogs/<AWS_account_Id>/CloudTrail/<region>/YYYY/MM/DD/
 # File Name: AccountID_CloudTrail_RegionName_YYYYMMDDTHHmmZ_UniqueString.json.gz / UniqueString=16 chars
-known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(CloudTrail)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(CloudTrail)_{aws_region_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{16}}.json.gz$'
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(CloudTrail)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(CloudTrail)_{aws_region_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{16}}\.json\.gz$'
 source: aws
 
 log_format: json

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -24,6 +24,7 @@ log_entries_key: Records
 annotations:
   log.source: aws.cloudtrail
   cloud.provider: aws
+  aws.service: cloudtrail
 
 requester: 
   - cloudtrail.amazonaws.com

--- a/src/log/processing/rules/aws/global-accelerator.yaml
+++ b/src/log/processing/rules/aws/global-accelerator.yaml
@@ -1,0 +1,44 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+name: global-accelerator
+
+# https://docs.aws.amazon.com/global-accelerator/latest/dg/monitoring-global-accelerator.flow-logs.html
+# Format: s3-bucket_name/s3-bucket-prefix/AWSLogs/aws_account_id/globalaccelerator/region/yyyy/mm/dd/aws_account_id_globalaccelerator_accelerator_id_flow_log_id_timestamp_hash.log.gz
+# Example file name: optional_prefix/AWSLogs/123456789012/globalaccelerator/us-west-2/2018/11/23/123456789012_globalaccelerator_1234abcd-abcd-1234-abcd-1234abcdefgh_20181123T0005Z_1fb12345.log.gz
+known_key_path_pattern: '^.*?{aws_logs_prefix}\/{aws_account_id_pattern}\/(globalaccelerator)\/{aws_region_pattern}\/{year_pattern}/{month_pattern}/{day_pattern}\/{aws_account_id_pattern}_(globalaccelerator)_{aws_global_accelerator_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$'
+
+source: aws
+
+log_format: text
+
+requester:
+  - delivery.logs.amazonaws.com
+
+annotations:
+  cloud.provider: aws
+  aws.service: global-accelerator
+
+
+attribute_extraction_from_key_name:
+  aws.account.id: '{aws_account_id_pattern}'
+  aws.region: '{aws_region_pattern}'
+  aws.resource.id: '{aws_global_accelerator_id_pattern}(?=_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$)'
+
+
+# https://docs.aws.amazon.com/global-accelerator/latest/dg/monitoring-global-accelerator.flow-logs.html#monitoring-global-accelerator.flow-logs.records.syntax
+attribute_extraction_grok_expression: '%{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE:timestamp} %{GREEDYDATA}'
+
+skip_header_lines: 1

--- a/src/log/processing/rules/aws/msk.yaml
+++ b/src/log/processing/rules/aws/msk.yaml
@@ -1,0 +1,40 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+name: msk
+
+
+# Example file name: AWSLogs/012345678910/KafkaBrokerLogs/us-east-1/demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20/2023-02-20-17/Broker-1_17-05_5b17f696.log.gz
+
+known_key_path_pattern: '^.*?{aws_logs_prefix}\/{aws_account_id_pattern}\/(KafkaBrokerLogs)/{aws_region_pattern}\/{aws_resource_name_pattern}\/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}\/(Broker)-\d{{1,3}}_{hour_pattern}-{minutes_pattern}_[a-fA-F0-9]{{8}}(\.log\.gz)$'
+
+source: aws
+
+log_format: text
+
+requester:
+  - delivery.logs.amazonaws.com
+
+annotations:
+  cloud.provider: aws
+  aws.service: msk
+
+attribute_extraction_from_key_name:
+  aws.account.id: '{aws_account_id_pattern}'
+  aws.region: '{aws_region_pattern}'
+  aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern})'
+
+attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp_to_transform})"
+

--- a/src/log/processing/rules/aws/msk.yaml
+++ b/src/log/processing/rules/aws/msk.yaml
@@ -35,6 +35,8 @@ attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
   aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern})'
+  aws.msk.broker: '(Broker)-\d{{1,3}}(?=_{hour_pattern}-{minutes_pattern}_[a-fA-F0-9]{{8}}(\.log\.gz)$)'
 
-attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp_to_transform})"
+
+attribute_extraction_grok_expression: '\[%{TIMESTAMP_ISO8601:timestamp_to_transform}\] %{LOGLEVEL:severity}'
 

--- a/src/log/processing/rules/aws/network-firewall.yaml
+++ b/src/log/processing/rules/aws/network-firewall.yaml
@@ -1,0 +1,47 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+name: network-firewall
+
+# https://docs.aws.amazon.com/network-firewall/latest/developerguide/logging-s3.html
+# File Name format: optional-s3-bucket-prefix/AWSLogs/aws-account-id/network-firewall/log-type/Region/firewall-name/timestamp/aws-account-id_network-firewall_log-type_Region_firewall-name_timestamp_hash.log.gz
+# Example file name: AWSLogs/012345678910/network-firewall/flow/us-east-1/my-test-firewall/2023/02/20/16/012345678910_network-firewall_flow_us-east-1_my-test-firewall_202302201610_e5c84094.log.gz
+
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(network-firewall)/(alert|flow)/{aws_region_pattern}/{aws_resource_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{aws_account_id_pattern}_(network-firewall)_(alert|flow)_{aws_region_pattern}_{aws_resource_name_pattern}_{year_pattern}{month_pattern}{day_pattern}{hour_pattern}{minutes_pattern}_[a-fA-F0-9]{{8}}(\.log\.gz)$'
+
+source: aws
+
+log_format: json_stream
+
+requester:
+  - delivery.logs.amazonaws.com
+
+annotations:
+  cloud.provider: aws
+  aws.service: network-firewall
+
+attribute_extraction_from_key_name:
+  aws.account.id: '{aws_account_id_pattern}'
+  aws.region: '{aws_region_pattern}'
+  # Should flow id be the log.source?
+  log.type: '(flow|alert)'
+  aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
+
+# https://docs.aws.amazon.com/network-firewall/latest/developerguide/firewall-logging.html#firewall-logging-contents
+# {"firewall_name":"test-firewall","availability_zone":"us-east-1b","event_timestamp":"1602627001","event":{"timestamp":"2020-10-13T22:10:01.006481+0000","flow_id":1582438383425873,"event_type":"alert","src_ip":"203.0.113.4","src_port":55555,"dest_ip":"192.0.2.16","dest_port":111,"proto":"TCP","alert":{"action":"allowed","signature_id":5,"rev":0,"signature":"test_tcp","category":"","severity":1}}}
+attribute_extraction_jmespath_expression:
+  #aws.resource.id: firewall_name
+  #aws.availability_zone: availability_zone
+  timestamp: event_timestamp

--- a/src/log/processing/rules/aws/nlb.yaml
+++ b/src/log/processing/rules/aws/nlb.yaml
@@ -19,7 +19,7 @@ name: NLB
 # File Name: aws-account-id_elasticloadbalancing_region_net.load-balancer-id_end-time_random-string.log.gz
 # Random string is 8 chars?
 # IMPORTANT: NLB Access Logs are only created if there's a TLS listener and they only contain information about TLS requests.
-known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(elasticloadbalancing)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(elasticloadbalancing)_{aws_region_pattern}_(net.){elbv2_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(.log.gz)$'
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(elasticloadbalancing)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(elasticloadbalancing)_{aws_region_pattern}_(net\.){elbv2_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
 source: aws
 
 log_format: text

--- a/src/log/processing/rules/aws/nlb.yaml
+++ b/src/log/processing/rules/aws/nlb.yaml
@@ -38,3 +38,6 @@ attribute_extraction_from_key_name:
   aws.region: '{aws_region_pattern}'
 
 attribute_extraction_grok_expression: "%{WORD:listener_type} %{NOTSPACE:version} %{TIMESTAMP_ISO8601:timestamp} %{DATA:elb_id} %{DATA:listener} %{IP:client_ip}:%{INT:client_port} %{IP:destination_ip}:%{INT:destination_port} %{INT:connection_time} %{INT:tls_handshake_time} %{INT:received_bytes} %{INT:sent_bytes} (?:-|%{INT:incoming_tls_alert}) (?:-|%{DATA:chosen_cert_arn}) (?:-|%{DATA:chosen_cert_serial}) (?:-|%{DATA:tls_cipher}) (?:-|%{DATA:tls_protocol_version}) (?:-|%{DATA:tls_named_group}) (?:-|%{DATA:domain_name}) (?:-|%{DATA:alpn_fe_protocol}) (?:-|%{DATA:alpn_be_protocol}) (?:-|%{GREEDYDATA:alpn_client_preference_list})"
+
+attribute_extraction_jmespath_expression:
+  aws.resource.id: elb_id

--- a/src/log/processing/rules/aws/redshift.yaml
+++ b/src/log/processing/rules/aws/redshift.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: redshift
+
+# Log file format: AWSLogs/AccountID/ServiceName/Region/Year/Month/Day/AccountID_ServiceName_Region_ClusterName_LogType_Timestamp.gz
+# example log file: AWSLogs/123456789012/redshift/us-east-1/2013/10/29/123456789012_redshift_us-east-1_mycluster_userlog_2013-10-29T18:01.gz
+
+known_key_path_pattern: '^.*?{aws_logs_prefix}\/{aws_account_id_pattern}\/(redshift)/{aws_region_pattern}\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{aws_account_id_pattern}_redshift_{aws_region_pattern}_{redshift_cluster_name_pattern}_(userlog|connectionlog|useractivitylog)_{year_pattern}-{month_pattern}-{day_pattern}T{hour_pattern}:{minutes_pattern}(\.gz)$'
+
+source: aws
+
+log_format: text
+
+requester:
+  - redshift.amazonaws.com
+  # opt-in regions have region-specific service-principal: redshift.region.amazonaws.com
+
+annotations:
+  cloud.provider: aws
+  aws.service: redshift
+
+# https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-manage-log-files
+attribute_extraction_from_key_name:
+  log.source: '(connectionlog|userlog|useractivitylog)(?=_{year_pattern}-{month_pattern}-{day_pattern}T{hour_pattern}:{minutes_pattern}(\.gz)$)'
+  aws.account.id: '{aws_account_id_pattern}'
+  aws.region: '{aws_region_pattern}'
+  aws.resource.id: '(?<=_){redshift_cluster_name_pattern}(?=_(connectionlog|userlog|useractivitylog)_{year_pattern}-{month_pattern}-{day_pattern}T{hour_pattern}:{minutes_pattern}(\.gz)$)'
+
+
+attribute_extraction_grok_expression: '%{REDSHIFTTIMESTAMP:timestamp_to_transform}'

--- a/src/log/processing/rules/aws/s3.yaml
+++ b/src/log/processing/rules/aws/s3.yaml
@@ -27,7 +27,6 @@ requester:
   - logging.s3.amazonaws.com
 
 annotations:
-  log.source: aws.s3
   cloud.provider: aws
   aws.service: s3
 

--- a/src/log/processing/rules/aws/s3.yaml
+++ b/src/log/processing/rules/aws/s3.yaml
@@ -1,0 +1,37 @@
+# Copyright 2022 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: s3
+
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html
+# Prefix: [/prefix]/YYYY-mm-DD-HH-MM-SS-UniqueString -> Unique string is a 16 HEX digits number
+# File Name example: 2022-10-03-10-13-50-A211246203787B7F
+# Random string is 8 chars?
+known_key_path_pattern: '^.*?/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}-{minutes_pattern}-{minutes_pattern}-[A-FZ0-9]{{16}}$'
+source: aws
+
+log_format: text
+
+requester:
+  - logging.s3.amazonaws.com
+
+annotations:
+  log.source: aws.s3
+  cloud.provider: aws
+  aws.service: s3
+
+attribute_extraction_grok_expression: "%{DATA} %{DATA:bucket_name} \\[%{DATA:timestamp_to_transform}\\]"
+
+attribute_extraction_jmespath_expression:
+  aws.resource.id: bucket_name

--- a/src/log/processing/rules/aws/s3.yaml
+++ b/src/log/processing/rules/aws/s3.yaml
@@ -18,7 +18,7 @@ name: s3
 # Prefix: [/prefix]/YYYY-mm-DD-HH-MM-SS-UniqueString -> Unique string is a 16 HEX digits number
 # File Name example: 2022-10-03-10-13-50-A211246203787B7F
 # Random string is 8 chars?
-known_key_path_pattern: '^.*?/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}-{minutes_pattern}-{minutes_pattern}-[A-FZ0-9]{{16}}$'
+known_key_path_pattern: '^.*?{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}-{minutes_pattern}-{minutes_pattern}-[A-F0-9]{{16}}$'
 source: aws
 
 log_format: text

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -34,9 +34,8 @@ annotations:
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:
   timestamp: query_timestamp
-  aws.account.id: account_id
-  aws.region: region
-  aws.resource.id: vpc_id
-  net.host.name: query_name
-  severity: "rcode == 'NOERROR' && 'INFO' || 'ERROR'"
-  
+  #aws.account.id: account_id
+  #aws.region: region
+  #aws.resource.id: vpc_id
+  #net.host.name: query_name
+  #severity: "rcode == 'NOERROR' && 'INFO' || 'ERROR'"

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -34,8 +34,8 @@ annotations:
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:
   timestamp: query_timestamp
-  #aws.account.id: account_id
-  #aws.region: region
-  #aws.resource.id: vpc_id
+  aws.account.id: account_id
+  aws.region: region
+  aws.resource.id: vpc_id
   #net.host.name: query_name
-  #severity: "rcode == 'NOERROR' && 'INFO' || 'ERROR'"
+  severity: "rcode == 'NOERROR' && 'INFO' || 'ERROR'"

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+name: vpcdnsquerylogs
+
+# https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html
+# File name example: AWSLogs/012345678910/vpcdnsquerylogs/vpc-0123456789abcdf12/2023/02/15/vpc-0123456789abcdf12_vpcdnsquerylogs_01234567890_20230215T0000Z_213be99c.log.gz
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(vpcdnsquerylogs)/{vpc_id_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{vpc_id_pattern}_(vpcdnsquerylogs)_{aws_account_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(.log.gz)$'
+
+source: aws
+
+log_format: json_stream
+
+requester:
+  - delivery.logs.amazonaws.com
+
+annotations:
+  log.source: aws.vpcdnsquerylogs
+  cloud.provider: aws
+  aws.service: route53
+
+# map message keys to DT LogsV2 API format  
+attribute_extraction_jmespath_expression:
+  timestamp: query_timestamp
+  aws.account.id: account_id
+  aws.region: region
+  aws.resource.id: vpc_id
+  net.host.name: query_name
+  severity: "rcode == 'NOERROR' && 'INFO' || 'ERROR'"
+  

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -16,8 +16,8 @@
 name: vpcdnsquerylogs
 
 # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html
-# File name example: AWSLogs/012345678910/vpcdnsquerylogs/vpc-0123456789abcdf12/2023/02/15/vpc-0123456789abcdf12_vpcdnsquerylogs_01234567890_20230215T0000Z_213be99c.log.gz
-known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(vpcdnsquerylogs)/{vpc_id_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{vpc_id_pattern}_(vpcdnsquerylogs)_{aws_account_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(.log.gz)$'
+# File name example: AWSLogs/012345678910/vpcdnsquerylogs/vpc-0123456789abcdf12/2023/02/15/vpc-0123456789abcdf12_vpcdnsquerylogs_012345678910_20230215T0000Z_213be99c.log.gz
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(vpcdnsquerylogs)/{vpc_id_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{vpc_id_pattern}_(vpcdnsquerylogs)_{aws_account_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$'
 
 source: aws
 

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -29,15 +29,13 @@ requester:
   - delivery.logs.amazonaws.com
 
 annotations:
-  #log.source: aws.vpcflowlogs
   cloud.provider: aws
   aws.service: vpc
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
-  # Should flow id be the log.source?
-  log.source: '{vpc_flow_id_pattern}'
+  aws.vpc.flow_log_id: '{vpc_flow_id_pattern}'
 
 # Standar log format: version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status
 attribute_extraction_grok_expression: '%{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE:timestamp} %{GREEDYDATA}'

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -1,0 +1,45 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+name: vpcflowlogs
+
+# VPC: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html#flow-logs-s3-path
+# Transit Gateway: https://docs.aws.amazon.com/vpc/latest/tgw/flow-logs-s3.html
+# File name format: optional-prefix/AWSLogs/account_id/vpcflowlogs/region/year/month/day/(?hour/)aws_account_id_vpcflowlogs_region_flow_log_id_YYYYMMDDTHHmmZ_hash.log.gz
+# File name example: AWSLogs/012345678910/vpcflowlogs/us-east-1/2023/02/14/012345678910_vpcflowlogs_us-east-1_fl-07f38b767c7cd46e3_20230214T0000Z_129a0cf7.log.gz
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(vpcflowlogs)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/({hour_pattern}/)?{aws_account_id_pattern}_(vpcflowlogs)_{aws_region_pattern}_{vpc_flow_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$'
+
+source: aws
+
+log_format: text
+
+requester:
+  - delivery.logs.amazonaws.com
+
+annotations:
+  #log.source: aws.vpcflowlogs
+  cloud.provider: aws
+  aws.service: vpc
+
+attribute_extraction_from_key_name:
+  aws.account.id: '{aws_account_id_pattern}'
+  aws.region: '{aws_region_pattern}'
+  # Should flow id be the log.source?
+  log.source: '{vpc_flow_id_pattern}'
+
+# Standar log format: version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status
+# attribute_extraction_grok_expression: 
+
+skip_header_lines: 1

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -40,6 +40,6 @@ attribute_extraction_from_key_name:
   log.source: '{vpc_flow_id_pattern}'
 
 # Standar log format: version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status
-# attribute_extraction_grok_expression: 
+attribute_extraction_grok_expression: '%{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE:timestamp} %{GREEDYDATA}'
 
 skip_header_lines: 1

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -1,0 +1,44 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: waf
+
+# https://docs.aws.amazon.com/waf/latest/developerguide/logging-s3.html
+# Prefix: [/prefix]/AWSLogs/(account_id)/WAFLogs/(region)/(acl-name)/yyyy/mm/dd/HH/MM/(account_id)_waflogs_(region)_(acl_name)_yymmddTHHMMZ_hash.log.gz
+# File Name example: AWSLogs/012345678910/WAFLogs/us-east-1/my-acl/2022/11/11/18/30/012345678910_waflogs_us-east-1_my-acl_20221111T1830Z_8e0a6094.log.gz
+# Hash string is 8 chars?
+
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/WAFLogs/{aws_region_pattern}/{wafv2_rule_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{minutes_pattern}/{aws_account_id_pattern}_(waflogs)_{aws_region_pattern}_{wafv2_rule_name_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(.log.gz)$'
+source: aws
+
+log_format: json_stream
+
+requester:
+  - delivery.logs.amazonaws.com
+
+annotations:
+  log.source: aws.wafv2
+  cloud.provider: aws
+  aws.service: wafv2
+
+attribute_extraction_from_key_name:
+  aws.account.id: '{aws_account_id_pattern}'
+  aws.region: '{aws_region_pattern}'
+  # Get the value before /yyyy/mm/dd/HH/MM as the waf rule name
+  aws.resource.id: '{wafv2_rule_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
+
+attribute_extraction_jmespath_expression:
+  timestamp: timestamp
+  aws.arn: webaclId
+  audit.action: action

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -28,7 +28,6 @@ requester:
   - delivery.logs.amazonaws.com
 
 annotations:
-  log.source: aws.wafv2
   cloud.provider: aws
   aws.service: wafv2
 

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -19,7 +19,7 @@ name: waf
 # File Name example: AWSLogs/012345678910/WAFLogs/us-east-1/my-acl/2022/11/11/18/30/012345678910_waflogs_us-east-1_my-acl_20221111T1830Z_8e0a6094.log.gz
 # Hash string is 8 chars?
 
-known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/WAFLogs/{aws_region_pattern}/{wafv2_rule_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{minutes_pattern}/{aws_account_id_pattern}_(waflogs)_{aws_region_pattern}_{wafv2_rule_name_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(.log.gz)$'
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/WAFLogs/{aws_region_pattern}/{aws_resource_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{minutes_pattern}/{aws_account_id_pattern}_(waflogs)_{aws_region_pattern}_{aws_resource_name_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
 source: aws
 
 log_format: json_stream
@@ -36,7 +36,7 @@ attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
   # Get the value before /yyyy/mm/dd/HH/MM as the waf rule name
-  aws.resource.id: '{wafv2_rule_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
+  aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
 
 attribute_extraction_jmespath_expression:
   timestamp: timestamp

--- a/src/log/processing/rules/custom/cwl-to-fh.yaml
+++ b/src/log/processing/rules/custom/cwl-to-fh.yaml
@@ -21,6 +21,9 @@ log_format: json_stream
 # from the stream of JSON objects, just select the ones with messageType: DATA_MESSAGE
 # (CWL sends CONTROL_MESSAGE messages to check deliverability to Firehose)
 filter_json_objects_key: messageType
+filter_json_objects_value: DATA_MESSAGE
+
+log_entries_key: logEvents
 
 annotations:
   log.source: aws.cloudwatch_logs

--- a/src/log/processing/rules/custom/cwl-to-fh.yaml
+++ b/src/log/processing/rules/custom/cwl-to-fh.yaml
@@ -21,10 +21,6 @@ log_format: json_stream
 # from the stream of JSON objects, just select the ones with messageType: DATA_MESSAGE
 # (CWL sends CONTROL_MESSAGE messages to check deliverability to Firehose)
 filter_json_objects_key: messageType
-filter_json_objects_value: DATA_MESSAGE
-
-# Within each JSON object in the stream, iterate through logEvents
-log_entries_key: logEvents
 
 annotations:
   log.source: aws.cloudwatch_logs

--- a/src/log/processing/rules/generic.yaml
+++ b/src/log/processing/rules/generic.yaml
@@ -23,4 +23,4 @@ source: generic
 log_format: text
 
 # Try to find timestamp value
-attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp}|%SYSLOGTIMESTAMP:timestamp})"
+attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp}|%{SYSLOGTIMESTAMP:timestamp})"

--- a/src/log/processing/rules/generic.yaml
+++ b/src/log/processing/rules/generic.yaml
@@ -21,3 +21,6 @@ known_key_path_pattern: '^.*$'
 source: generic
 
 log_format: text
+
+# Try to find timestamp value
+attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp}|%SYSLOGTIMESTAMP:timestamp})"

--- a/src/log/processing/rules/generic.yaml
+++ b/src/log/processing/rules/generic.yaml
@@ -23,4 +23,4 @@ source: generic
 log_format: text
 
 # Try to find timestamp value
-attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp}|%{SYSLOGTIMESTAMP:timestamp})"
+attribute_extraction_grok_expression: "(?:%{TIMESTAMP_ISO8601:timestamp_to_transform}|%{SYSLOGTIMESTAMP:timestamp_to_transform})"

--- a/src/utils/config/cloudwatch_logs_attribute_map.yaml
+++ b/src/utils/config/cloudwatch_logs_attribute_map.yaml
@@ -1,0 +1,56 @@
+# Copyright 2023 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+eks:
+  log_group_name:
+    aws.resource.id:
+      operation: split
+      parameters:
+        delimiter: "/"
+        attribute_index: 3
+  log_stream_name:
+    log.source: 
+      operation: find_strings
+      parameters:
+        strings:
+          - kube-apiserver-audit
+          - kube-apiserver
+          - authenticator
+          - kube-controller-manager
+          - kube-scheduler
+          - cloud-controller-manager
+lambda:
+  log_group_name:
+    aws.resource.id: 
+      operation: split
+      parameters:
+        delimiter: "/"
+        attribute_index: 3
+  log_stream_name: {}
+
+route53: 
+  # CloudWatch Log Group is user defined. For the forwarder to pick it up must be 
+  # /aws/route53/...
+  log_group_name: {}
+  log_stream_name:
+    aws.resource.id: 
+      operation: split
+      parameters:
+        delimiter: "/"
+        attribute_index: 0
+    aws.edge_location: 
+      operation: split
+      parameters:
+        delimiter: "/"
+        attribute_index: 1

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -110,14 +110,14 @@ def get_attributes_from_cloudwatch_logs_data(log_group_name,log_stream_name):
                     "operation": "split",
                     "parameters": {
                         "delimiter": "/",
-                        "attribute_index": 1
+                        "attribute_index": 0
                     }
                 },
                 "aws.edge_location": {
                     "operation": "split",
                     "parameters": {
                         "delimiter": "/",
-                        "attribute_index": 2
+                        "attribute_index": 1
                     }
                 }
             }

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -34,7 +34,8 @@ helper_regexes = {
     'aws_resource_name_pattern': r'[a-zA-Z0-9-_]{1,128}',
     'vpc_id_pattern': r'vpc-[0-9a-f]{8}(?:[0-9a-f]{9})?',
     'cloudfront_distribution_id_pattern': r'E[A-Z0-9]{13}',
-    'vpc_flow_id_pattern': r'fl-[0-9a-f]{8}(?:[0-9a-f]{9})?'
+    'vpc_flow_id_pattern': r'fl-[0-9a-f]{8}(?:[0-9a-f]{9})?',
+    'aws_global_accelerator_id_pattern': r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}'
 }
 
 custom_grok_expressions = {

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -30,7 +30,8 @@ helper_regexes = {
     'classic_load_balancer_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]',
     # ALB / NLB Load Balancer id can be up to 48 chars, and / is substituted with .,
     'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,46}[a-zA-Z0-9]',
-    'ipv4_address_pattern' : r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
+    'ipv4_address_pattern' : r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
+    'wafv2_rule_name_pattern': r'[a-zA-Z0-9-_]{1,128}'
 }
 
 def get_split_member(params,name):
@@ -52,13 +53,6 @@ def get_attributes_from_cloudwatch_logs_data(log_group_name,log_stream_name):
             # /aws/eks/cluster-name/cluster
             "log_group_name": {
                 "aws.resource.id": {
-                    "operation": "split",
-                    "parameters": {
-                        "delimiter" :"/",
-                        "attribute_index": 3
-                    }
-                },
-                "k8s.cluster.name": {
                     "operation": "split",
                     "parameters": {
                         "delimiter" :"/",

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -32,7 +32,13 @@ helper_regexes = {
     'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,46}[a-zA-Z0-9]',
     'ipv4_address_pattern' : r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
     'wafv2_rule_name_pattern': r'[a-zA-Z0-9-_]{1,128}',
-    'vpc_id_pattern': r'vpc\-[0-9a-f]{8}(?:[0-9a-f]{9})?'
+    'vpc_id_pattern': r'vpc-[0-9a-f]{8}(?:[0-9a-f]{9})?',
+    'cloudfront_distribution_id_pattern': r'E[A-Z0-9]{13}'
+}
+
+custom_grok_expressions = {
+    # grab timestamp from CloudFront log (YYY-mm-dd\tHH:MM:SS)
+    'CLOUDFRONTTIMESTAMP' : '%{YEAR}-%{MONTHNUM}-%{MONTHDAY}%{SPACE}%{TIME}'
 }
 
 def get_split_member(params,name):

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -31,9 +31,10 @@ helper_regexes = {
     # ALB / NLB Load Balancer id can be up to 48 chars, and / is substituted with .,
     'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,46}[a-zA-Z0-9]',
     'ipv4_address_pattern' : r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
-    'wafv2_rule_name_pattern': r'[a-zA-Z0-9-_]{1,128}',
+    'aws_resource_name_pattern': r'[a-zA-Z0-9-_]{1,128}',
     'vpc_id_pattern': r'vpc-[0-9a-f]{8}(?:[0-9a-f]{9})?',
-    'cloudfront_distribution_id_pattern': r'E[A-Z0-9]{13}'
+    'cloudfront_distribution_id_pattern': r'E[A-Z0-9]{13}',
+    'vpc_flow_id_pattern': r'fl-[0-9a-f]{8}(?:[0-9a-f]{9})?'
 }
 
 custom_grok_expressions = {

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -31,7 +31,8 @@ helper_regexes = {
     # ALB / NLB Load Balancer id can be up to 48 chars, and / is substituted with .,
     'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,46}[a-zA-Z0-9]',
     'ipv4_address_pattern' : r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
-    'wafv2_rule_name_pattern': r'[a-zA-Z0-9-_]{1,128}'
+    'wafv2_rule_name_pattern': r'[a-zA-Z0-9-_]{1,128}',
+    'vpc_id_pattern': r'vpc\-[0-9a-f]{8}(?:[0-9a-f]{9})?'
 }
 
 def get_split_member(params,name):

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -11,6 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
+import yaml
 
 ENCODING = 'utf-8'
 
@@ -55,74 +57,23 @@ def get_string_found(params,name):
 
     return ''
 
+def load_cloudwatch_logs_attribute_mappings() -> dict:
+    '''
+    Loads the YAML file with attribute mappings for CloudWatch Logs services
+    '''
+
+    file = os.path.dirname(__file__) + "/config/cloudwatch_logs_attribute_map.yaml"
+
+    with open(file, encoding=ENCODING) as mappings_file:
+        cwl_mappings = yaml.load(mappings_file,Loader=yaml.loader.SafeLoader)
+
+    return cwl_mappings
+
 def get_attributes_from_cloudwatch_logs_data(log_group_name,log_stream_name):
     '''
     Extracts AWS attributes given a CloudWatch Logs Log Group and Log Stream names
     '''
-    aws_service_cw_logs_attribute_map = {
-        "eks": {
-            # /aws/eks/cluster-name/cluster
-            "log_group_name": {
-                "aws.resource.id": {
-                    "operation": "split",
-                    "parameters": {
-                        "delimiter" :"/",
-                        "attribute_index": 3
-                    }
-                }
-            },
-            # kube-api-server
-            "log_stream_name": {
-                "log.source": {
-                    "operation": "find_strings",
-                    "parameters": {
-                        "strings": [
-                            "kube-apiserver-audit",
-                            "kube-apiserver",
-                            "authenticator",
-                            "kube-controller-manager",
-                            "kube-scheduler",
-                            "cloud-controller-manager"
-                        ]
-                    }
-                }
-
-            }
-        },
-        "lambda": {
-            "log_group_name": {
-                "aws.resource.id": {
-                    "operation": "split",
-                    "parameters": {
-                        "delimiter" :"/",
-                        "attribute_index": 3
-                    }
-                }
-            },
-            "log_stream_name": {}
-        },
-        # CloudWatch Log Group is user defined. For the forwarder to pick it up must be 
-        # /aws/route53/...
-        "route53": {
-            "log_group_name": {},
-            "log_stream_name": {
-                "aws.resource.id": {
-                    "operation": "split",
-                    "parameters": {
-                        "delimiter": "/",
-                        "attribute_index": 0
-                    }
-                },
-                "aws.edge_location": {
-                    "operation": "split",
-                    "parameters": {
-                        "delimiter": "/",
-                        "attribute_index": 1
-                    }
-                }
-            }
-        }
-    }
+    aws_service_cw_logs_attribute_map = load_cloudwatch_logs_attribute_mappings()
 
     options = {
         "split": get_split_member,

--- a/template.yaml
+++ b/template.yaml
@@ -403,7 +403,7 @@ Resources:
   AppConfigDeploymentStrategy:
     Type: AWS::AppConfig::DeploymentStrategy
     Properties:
-      Name: !Sub ${AWS::StackName}-AllAtOnce-Deployment-Strategy
+      Name: !Sub ${AWS::StackName}-AllAtOnce
       DeploymentDurationInMinutes: 0
       FinalBakeTimeInMinutes: 0
       GrowthFactor: 100

--- a/template.yaml
+++ b/template.yaml
@@ -158,9 +158,9 @@ Mappings:
     # Mappings only support alphanumeric chars, '-' and '.', so name can't be x86_64
     # That means to resolve the image tag we need !If [ ArchIsArm , !FindInMap arm, !FindInMap x86]
     x86: 
-      Tag: '3.9.2023.02.03.11-x86_64'
+      Tag: '3.9.2023.02.28.15-x86_64'
     arm64:
-      Tag: '3.9.2023.02.03.11-arm64'
+      Tag: '3.9.2023.02.28.15-arm64'
 
 Resources:
   QueueProcessingFunction:
@@ -403,7 +403,7 @@ Resources:
   AppConfigDeploymentStrategy:
     Type: AWS::AppConfig::DeploymentStrategy
     Properties:
-      Name: !Sub ${AWS::StackName}-AllAtOnce
+      Name: !Sub ${AWS::StackName}-AllAtOnce-Deployment-Strategy
       DeploymentDurationInMinutes: 0
       FinalBakeTimeInMinutes: 0
       GrowthFactor: 100

--- a/tests/e2e/clean_up_resources.sh
+++ b/tests/e2e/clean_up_resources.sh
@@ -2,6 +2,8 @@
 
 # Settings for CloudWatch Log Export job
 PREFIX="test/${TRAVIS_BUILD_ID}/lambda-logs"
+STACK_NAME=e2e-dt-aws-s3-log-forwarder-${TRAVIS_BUILD_ID}
+E2E_TESTING_BUCKET_NAME=dynatrace-aws-s3-log-forwarder-e2e-testing
 LAMBDA_FUNCTION_NAME=$(aws cloudformation describe-stacks --stack-name ${STACK_NAME} --query \
                          'Stacks[].Outputs[?OutputKey==`QueueProcessingFunction`].OutputValue' \
                          --output text | cut -d':' -f7)

--- a/tests/e2e/local_app.py
+++ b/tests/e2e/local_app.py
@@ -134,7 +134,7 @@ if os.environ['AWS_SAM_LOCAL'] == 'True':
         client.put_parameter(Name=api_key_parameter, Type='SecureString',
                              Value=os.environ['DYNATRACE_1_API_KEY'])
 
-    class Test_Context():
+    class test_context():
         def __init__(self):
             self.invoked_function_arn = 'test'
 
@@ -151,7 +151,7 @@ if os.environ['AWS_SAM_LOCAL'] == 'True':
         save_test_ssm_parameters()
         events = load_s3_test_data_from_disk()
         
-        lambda_handler(json.loads(events), Test_Context())
+        lambda_handler(json.loads(events), test_context())
 
 if __name__ == '__main__':
     run_locally()

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -437,5 +437,45 @@ class testGlobalAcceleratorLogs(unittest.TestCase):
         extracted_attributes = self.global_accelerator_processing_rule.get_extracted_log_attributes(self.log_entry)
         self.assertEqual(extracted_attributes,self.expected_attributes)
 
+class testCWLtoFirehoseLogs(unittest.TestCase):
+
+    def test_route53_public_query_logs(self):
+        log_entry = {
+            'content': '1.0 2023-02-21T16:34:06Z Z0195849T189REVYAU10 test.ivallho.com A NOERROR UDP MAD51-C2 79.157.104.114 -',
+            'aws.log_group': '/aws/route53/public/example.com',
+            'aws.log_stream': 'Z0195849T189REVYAU10/MAD51-C2',
+            'aws.log_event_id': '37398288281683578257046633068901495458990097452373442560',
+            'timestamp': '2023-02-21T16:34:06Z'
+        }
+        expected_attributes = {
+            'timestamp':'2023-02-21T16:34:06Z',
+            'aws.service': 'route53',
+            'aws.resource.id': 'Z0195849T189REVYAU10',
+            'aws.edge_location': 'MAD51-C2'
+        }
+
+        extracted_attributes = processing_rules['custom']['cwl_to_fh'].get_extracted_log_attributes(log_entry)
+        self.assertEqual(extracted_attributes,expected_attributes)
+
+    def test_eks_control_plane_logs(self):
+
+        log_entry = {
+            'content': 'I0221 18:41:59.098346      10 cleaner.go:172] Cleaning CSR "csr-lrn9z" as it is more than 1h0m0s old and approved.',
+            'aws.log_group': '/aws/eks/my-cluster-name/cluster',
+            'aws.log_stream': 'kube-controller-manager-1e770729c82dc68998d47f9f28408516',
+            'aws.log_event_id': '37398288281683578257046633068901495458990097452373442560',
+            'timestamp': '2023-02-21T16:34:06Z'
+        }
+
+        expected_attributes = {
+            'timestamp':'2023-02-21T16:34:06Z',
+            'aws.service': 'eks',
+            'aws.resource.id': 'my-cluster-name',
+            'log.source': 'kube-controller-manager'
+        }
+
+        extracted_attributes = processing_rules['custom']['cwl_to_fh'].get_extracted_log_attributes(log_entry)
+        self.assertEqual(extracted_attributes,expected_attributes)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -87,7 +87,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
     expected_attributes = {
                             'request_type': 'http',
                             'timestamp': '2022-09-27T15:28:18.612792Z',
-                            'elbv2_id': 'app/k8s-podinfo-podinfoi-ffbc3dc280/82a34fae168ba1aa',
                             'client_ip': '54.25.124.220',
                             'client_port': 63763,
                             'target_ip': '192.168.15.219',
@@ -104,25 +103,17 @@ class TestALBAttributeExtraction(unittest.TestCase):
                             'urihost': 'k8s-podinfo-podinfoi-ffbc3dc280-1325129400.us-east-1.elb.amazonaws.com:80',
                             'port': '80',
                             'uripath': '/',
-                            'uriparam': None,
                             'http_version': 'HTTP/1.1',
                             'user_agent': 'curl/7.79.1',
-                            'ssl_cipher': None,
-                            'ssl_protocol': None,
                             'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/k8s-podinfo-frontend-b634dbe3b4/c0bcccc5dfc7c29c',
                             'x_amzn_trace_id': 'Root=1-63331692-0dd6b14130c01d3e378a6ea5',
-                            'domain_name': None,
-                            'chosen_cert_arn': None,
                             'matched_rule_priority': '1',
                             'request_creation_time': '2022-09-27T15:28:18.565000Z',
                             'actions_executed': 'forward',
-                            'redirect_url': None,
-                            'error_reason': None,
                             'target_port_list': '192.168.15.219:9898',
                             'target_status_code_list': '200',
-                            'classification': None,
-                            'classification_reason': None,
-                            'severity': 'INFO'
+                            'severity': 'INFO',
+                            'aws.resource.id': 'app/k8s-podinfo-podinfoi-ffbc3dc280/82a34fae168ba1aa'
                          }
     alb_processing_rule = processing_rules['aws']['ALB']
 
@@ -134,7 +125,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
         log_entry = 'http 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.000 0.001 0.000 200 200 34 366 "GET http://www.example.com:80/ HTTP/1.1" "curl/7.46.0" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337262-36d228ad5d99923122bbe354" "-" "-" 0 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
         expected_attributes = { 'request_type': 'http',
                                 'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188',
                                 'client_ip': '192.168.131.39',
                                 'client_port': 2817,
                                 'target_ip': '10.0.0.1',
@@ -151,25 +141,17 @@ class TestALBAttributeExtraction(unittest.TestCase):
                                 'urihost': 'www.example.com:80',
                                 'port': '80',
                                 'uripath': '/',
-                                'uriparam': None,
                                 'http_version': 'HTTP/1.1',
                                 'user_agent': 'curl/7.46.0',
-                                'ssl_cipher': None,
-                                'ssl_protocol': None,
                                 'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
                                 'x_amzn_trace_id': 'Root=1-58337262-36d228ad5d99923122bbe354',
-                                'domain_name': None,
-                                'chosen_cert_arn': None,
                                 'matched_rule_priority': '0',
                                 'request_creation_time': '2018-07-02T22:22:48.364000Z',
                                 'actions_executed': 'forward',
-                                'redirect_url': None,
-                                'error_reason': None,
                                 'target_port_list': '10.0.0.1:80',
                                 'target_status_code_list': '200',
-                                'classification': None,
-                                'classification_reason': None,
-                                'severity': 'INFO'
+                                'severity': 'INFO',
+                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
                             }
 
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
@@ -179,7 +161,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
         log_entry = 'https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.086 0.048 0.037 200 200 0 57 "GET https://www.example.com:443/ HTTP/1.1" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337281-1d84f3d73c47ec4e58577259" "www.example.com" "arn:aws:acm:us-east-2:123456789012:certificate/12345678-1234-1234-1234-123456789012" 1 2018-07-02T22:22:48.364000Z "authenticate,forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
         expected_attributes = { 'request_type': 'https',
                                 'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188',
                                 'client_ip': '192.168.131.39',
                                 'client_port': 2817,
                                 'target_ip': '10.0.0.1',
@@ -196,7 +177,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
                                 'urihost': 'www.example.com:443',
                                 'port': '443',
                                 'uripath': '/',
-                                'uriparam': None,
                                 'http_version': 'HTTP/1.1',
                                 'user_agent': 'curl/7.46.0',
                                 'ssl_cipher': 'ECDHE-RSA-AES128-GCM-SHA256',
@@ -208,13 +188,10 @@ class TestALBAttributeExtraction(unittest.TestCase):
                                 'matched_rule_priority': '1',
                                 'request_creation_time': '2018-07-02T22:22:48.364000Z',
                                 'actions_executed': 'authenticate,forward',
-                                'redirect_url': None,
-                                'error_reason': None,
                                 'target_port_list': '10.0.0.1:80',
                                 'target_status_code_list': '200',
-                                'classification': None,
-                                'classification_reason': None,
-                                'severity': 'INFO'
+                                'severity': 'INFO',
+                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
                             }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
@@ -223,7 +200,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
         log_entry = 'h2 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.1.252:48160 10.0.0.66:9000 0.000 0.002 0.000 200 200 5 257 "GET https://10.0.2.105:773/ HTTP/2.0" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337327-72bd00b0343d75b906739c42" "-" "-" 1 2018-07-02T22:22:48.364000Z "redirect" "https://example.com:80/" "-" "10.0.0.66:9000" "200" "-" "-"'
         expected_attributes = { 'request_type': 'h2', 
                                 'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188',
                                 'client_ip': '10.0.1.252',
                                 'client_port': 48160,
                                 'target_ip': '10.0.0.66',
@@ -240,25 +216,20 @@ class TestALBAttributeExtraction(unittest.TestCase):
                                 'urihost': '10.0.2.105:773',
                                 'port': '773',
                                 'uripath': '/',
-                                'uriparam': None,
                                 'http_version': 'HTTP/2.0',
                                 'user_agent': 'curl/7.46.0',
                                 'ssl_cipher': 'ECDHE-RSA-AES128-GCM-SHA256',
                                 'ssl_protocol': 'TLSv1.2',
                                 'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
                                 'x_amzn_trace_id': 'Root=1-58337327-72bd00b0343d75b906739c42',
-                                'domain_name': None,
-                                'chosen_cert_arn': None,
                                 'matched_rule_priority': '1',
                                 'request_creation_time': '2018-07-02T22:22:48.364000Z',
                                 'actions_executed': 'redirect',
                                 'redirect_url': 'https://example.com:80/',
-                                'error_reason': None,
                                 'target_port_list': '10.0.0.66:9000',
                                 'target_status_code_list': '200',
-                                'classification': None,
-                                'classification_reason': None,
-                                'severity': 'INFO' }
+                                'severity': 'INFO',
+                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188' }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
     
@@ -266,7 +237,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
         log_entry = 'ws 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.0.140:40914 10.0.1.192:8010 0.001 0.003 0.000 101 101 218 587 "GET http://10.0.0.30:80/ HTTP/1.1" "-" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-" 1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.1.192:8010" "101" "-" "-"'
         expected_attributes = { 'request_type': 'ws',
                                 'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188',
                                 'client_ip': '10.0.0.140',
                                 'client_port': 40914,
                                 'target_ip': '10.0.1.192',
@@ -283,25 +253,17 @@ class TestALBAttributeExtraction(unittest.TestCase):
                                 'urihost': '10.0.0.30:80',
                                 'port': '80',
                                 'uripath': '/',
-                                'uriparam': None,
                                 'http_version': 'HTTP/1.1',
                                 'user_agent': '-',
-                                'ssl_cipher': None,
-                                'ssl_protocol': None,
                                 'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
                                 'x_amzn_trace_id': 'Root=1-58337364-23a8c76965a2ef7629b185e3',
-                                'domain_name': None,
-                                'chosen_cert_arn': None,
                                 'matched_rule_priority': '1',
                                 'request_creation_time': '2018-07-02T22:22:48.364000Z',
                                 'actions_executed': 'forward',
-                                'redirect_url': None,
-                                'error_reason': None,
                                 'target_port_list': '10.0.1.192:8010',
                                 'target_status_code_list': '101',
-                                'classification': None,
-                                'classification_reason': None,
-                                'severity': 'INFO'
+                                'severity': 'INFO',
+                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
                             }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
@@ -309,7 +271,6 @@ class TestALBAttributeExtraction(unittest.TestCase):
 class TestClassicELBAttributeExtraction(unittest.TestCase):
     classic_elb_test_entry = '2022-09-27T22:48:26.330387Z a2e8277e0e09143fbb06db5dcd2a14c2 3.67.7.163:8596 192.168.18.161:32728 0.000042 0.004504 0.000036 404 404 0 1086 "GET http://a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80/n9BxiYVakde9.php HTTP/1.1" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)" - -'
     expected_attributes = { "timestamp": "2022-09-27T22:48:26.330387Z",
-                            "elb": "a2e8277e0e09143fbb06db5dcd2a14c2",
                             "client_ip": "3.67.7.163",
                             "client_port": 8596,
                             "backend_ip": "192.168.18.161",
@@ -327,13 +288,10 @@ class TestClassicELBAttributeExtraction(unittest.TestCase):
                             "urihost": "a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80",
                             "port": "80",
                             "path": "/n9BxiYVakde9.php",
-                            "params": None,
                             "httpversion": "1.1",
-                            "rawrequest": None,
                             "user_agent": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-                            "ssl_cipher": None,
-                            "ssl_protocol": None,
-                            "severity": "WARN"
+                            "severity": "WARN",
+                            "aws.resource.id": "a2e8277e0e09143fbb06db5dcd2a14c2"
                           }
 
     classic_elb_processing_rule = processing_rules['aws']['Classic-ELB']
@@ -348,7 +306,6 @@ class TestNLBAttributeExtraction(unittest.TestCase):
     expected_attributes = { 'listener_type': 'tls',
                             'version': '2.0',
                             'timestamp': '2022-09-27T17:10:23',
-                            'elb_id': 'net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff',
                             'listener': 'f0f22c45225e4663',
                             'client_ip': '192.168.18.161',
                             'client_port': '60808',
@@ -358,16 +315,11 @@ class TestNLBAttributeExtraction(unittest.TestCase):
                             'tls_handshake_time': '16',
                             'received_bytes': '140',
                             'sent_bytes': '518',
-                            'incoming_tls_alert': None,
                             'chosen_cert_arn': 'arn:aws:acm:us-east-1:012345678910:certificate/ae6e87cd-9848-465b-9433-b0d34850a685',
-                            'chosen_cert_serial': None,
                             'tls_cipher': 'ECDHE-RSA-AES128-GCM-SHA256',
                             'tls_protocol_version': 'tlsv12',
-                            'tls_named_group': None,
                             'domain_name': 'k8s-podinfo-frontend-352ef7564b-809b86b470cfa0ff.elb.us-east-1.amazonaws.com',
-                            'alpn_fe_protocol': None,
-                            'alpn_be_protocol': None,
-                            'alpn_client_preference_list': None
+                            'aws.resource.id': 'net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff'
                         }
     nlb_processing_rule = processing_rules['aws']['NLB']
 

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -424,5 +424,18 @@ class testMSKLogs(unittest.TestCase):
         extracted_attributes = self.msk_processing_rule.get_extracted_log_attributes(self.log_entry)
         self.assertEqual(extracted_attributes,self.expected_attributes)
 
+class testGlobalAcceleratorLogs(unittest.TestCase):
+    log_entry = '2.0 512220559759 f0154cf1-4ac0-451b-87a2-5b2ce89142e6 1.2.3.4 57825 5.6.7.8 80 172.31.25.4 80 TCP IPV4 0 0 1676984801 1676984809 ACCEPT OK - 0 us-east-1 JFK6-2 INGRESS vpc-01234567891abcdef'
+
+    expected_attributes = {
+        'timestamp': '1676984801'
+    }
+
+    global_accelerator_processing_rule = processing_rules['aws']['global-accelerator']
+
+    def test_global_accelerator_logs(self):
+        extracted_attributes = self.global_accelerator_processing_rule.get_extracted_log_attributes(self.log_entry)
+        self.assertEqual(extracted_attributes,self.expected_attributes)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -410,5 +410,18 @@ class testCloudFrontLogs(unittest.TestCase):
         extracted_attributes = self.cloudfront_processing_rule.get_extracted_log_attributes(self.log_entry)
         self.assertEqual(extracted_attributes, self.expected_attributes)
 
+class testMSKLogs(unittest.TestCase):
+    log_entry = '[2023-02-20 17:10:36,845] INFO App info kafka.consumer for consumer-consumer-lag-19 unregistered (org.apache.kafka.common.utils.AppInfoParser)'
+
+    expected_attributes = {
+        'timestamp': '2023-02-20T17:10:36.845000'
+    }
+
+    msk_processing_rule = processing_rules['aws']['msk']
+
+    def test_msk_logs(self):
+        extracted_attributes = self.msk_processing_rule.get_extracted_log_attributes(self.log_entry)
+        self.assertEqual(extracted_attributes,self.expected_attributes)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -414,7 +414,8 @@ class testMSKLogs(unittest.TestCase):
     log_entry = '[2023-02-20 17:10:36,845] INFO App info kafka.consumer for consumer-consumer-lag-19 unregistered (org.apache.kafka.common.utils.AppInfoParser)'
 
     expected_attributes = {
-        'timestamp': '2023-02-20T17:10:36.845000'
+        'timestamp': '2023-02-20T17:10:36.845000',
+        'severity': 'INFO'
     }
 
     msk_processing_rule = processing_rules['aws']['msk']

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -354,7 +354,47 @@ class TestWAFLogAttributeExtraction(unittest.TestCase):
 
     def test_waf_attribute_extraction(self):
         extracted_attributes = self.waf_processing_rule.get_extracted_log_attributes(self.waf_log_entry)
-        print(extracted_attributes)
+        self.assertEqual(extracted_attributes, self.expected_attributes)
+
+class TestVPCDNSquerylogs(unittest.TestCase):
+    log_entry = {
+          "version": "1.100000",
+          "account_id": "012345678910",
+          "region": "us-east-1",
+          "vpc_id": "vpc-0123456789abcdef12",
+          "query_timestamp": "2023-02-15T18:33:54Z",
+          "query_name": "ec2messages.us-east-1.amazonaws.com.",
+          "query_type": "A",
+          "query_class": "IN",
+          "rcode": "NOERROR",
+          "answers": [
+            {
+              "Rdata": "5.6.7.8",
+              "Type": "A",
+              "Class": "IN"
+            }
+          ],
+          "srcaddr": "1.2.3.4",
+          "srcport": "38900",
+          "transport": "UDP",
+          "srcids": {
+            "instance": "i-0db59e1c912332372"
+          }
+        }
+
+    expected_attributes = {
+        "timestamp": '2023-02-15T18:33:54Z',
+        "aws.account.id": "012345678910",
+        "aws.region": "us-east-1",
+        "aws.resource.id": "vpc-0123456789abcdef12",
+        "net.host.name": "ec2messages.us-east-1.amazonaws.com.",
+        "severity": "INFO"
+    }
+
+    vpcdnsquery_processing_rule = processing_rules['aws']['vpcdnsquerylogs']
+
+    def test_vpcdnsquerylogs_attribute_extraction(self):
+        extracted_attributes = self.vpcdnsquery_processing_rule.get_extracted_log_attributes(self.log_entry)
         self.assertEqual(extracted_attributes, self.expected_attributes)
 
 if __name__ == '__main__':

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -383,18 +383,31 @@ class TestVPCDNSquerylogs(unittest.TestCase):
         }
 
     expected_attributes = {
-        "timestamp": '2023-02-15T18:33:54Z',
-        "aws.account.id": "012345678910",
-        "aws.region": "us-east-1",
-        "aws.resource.id": "vpc-0123456789abcdef12",
-        "net.host.name": "ec2messages.us-east-1.amazonaws.com.",
-        "severity": "INFO"
+        "timestamp": '2023-02-15T18:33:54Z'
+        #"aws.account.id": "012345678910",
+        #"aws.region": "us-east-1",
+        #"aws.resource.id": "vpc-0123456789abcdef12",
+        #"net.host.name": "ec2messages.us-east-1.amazonaws.com.",
+        #"severity": "INFO"
     }
 
     vpcdnsquery_processing_rule = processing_rules['aws']['vpcdnsquerylogs']
 
     def test_vpcdnsquerylogs_attribute_extraction(self):
         extracted_attributes = self.vpcdnsquery_processing_rule.get_extracted_log_attributes(self.log_entry)
+        self.assertEqual(extracted_attributes, self.expected_attributes)
+
+class testCloudFrontLogs(unittest.TestCase):
+    log_entry = '2023-02-16	14:11:45	HEL50-C2	926	213.27.198.18	GET	d2p3hufu2xzzmv.cloudfront.net	/	200	-	curl/7.79.1	-	-	Hit	4hywY-pj7l9Wpc1WaHT2rUoyuuxTe_GT7aY2CkbFxOhYrC_qbqRTtQ==	d2p3hufu2xzzmv.cloudfront.net	https	51	0.026	-	TLSv1.3	TLS_AES_128_GCM_SHA256	Hit	HTTP/2.0	-	-	9428	0.026	Hit	text/html	615	-	-'
+
+    expected_attributes = {
+        'timestamp': '2023-02-16T14:11:45'
+    }
+
+    cloudfront_processing_rule = processing_rules['aws']['cloudfront']
+
+    def test_cloudfrontlogs_attribute_extraction(self):
+        extracted_attributes = self.cloudfront_processing_rule.get_extracted_log_attributes(self.log_entry)
         self.assertEqual(extracted_attributes, self.expected_attributes)
 
 if __name__ == '__main__':

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -327,5 +327,35 @@ class TestNLBAttributeExtraction(unittest.TestCase):
         extracted_attributes = self.nlb_processing_rule.get_extracted_log_attributes(self.nlb_test_entry)
         self.assertEqual(self.expected_attributes,extracted_attributes)
 
+class TestS3AccessLogsAttributeExtraction(unittest.TestCase):
+    s3_access_log_entry = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be DOC-EXAMPLE-BUCKET1 [06/Feb/2019:00:00:38 +0000] 192.0.2.3 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE REST.GET.VERSIONING - "GET /DOC-EXAMPLE-BUCKET1?versioning HTTP/1.1" 200 - 113 - 7 - "-" "S3Console/0.4" - s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234= SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader DOC-EXAMPLE-BUCKET1.s3.us-west-1.amazonaws.com TLSV1.2 arn:aws:s3:us-west-1:123456789012:accesspoint/example-AP Yes'
+
+    expected_attributes = {
+        'aws.resource.id': 'DOC-EXAMPLE-BUCKET1',
+        'timestamp': '2019-02-06T00:00:38+00:00'
+    }
+
+    s3_processing_rule = processing_rules['aws']['s3']
+
+    def test_s3_attribute_extraction(self):
+        extracted_attributes = self.s3_processing_rule.get_extracted_log_attributes(self.s3_access_log_entry)
+        self.assertEqual(self.expected_attributes,extracted_attributes)
+
+class TestWAFLogAttributeExtraction(unittest.TestCase):
+    waf_log_entry = {"timestamp":1668191404453,"formatVersion":1,"webaclId":"arn:aws:wafv2:us-east-1:012345678910:regional/webacl/my-web-acl/5b291f89-a9c6-496f-bc56-28fe34178f25","terminatingRuleId":"Default_Action","terminatingRuleType":"REGULAR","action":"ALLOW","terminatingRuleMatchDetails":[],"httpSourceName":"ALB","httpSourceId":"012345678910-app/my-lb/083081a32688b957","ruleGroupList":[{"ruleGroupId":"AWS#AWSManagedRulesKnownBadInputsRuleSet","terminatingRule":None,"nonTerminatingMatchingRules":[],"excludedRules":None,"customerConfig":None},{"ruleGroupId":"AWS#AWSManagedRulesLinuxRuleSet","terminatingRule":None,"nonTerminatingMatchingRules":[],"excludedRules":None,"customerConfig":None},{"ruleGroupId":"AWS#AWSManagedRulesPHPRuleSet","terminatingRule":None,"nonTerminatingMatchingRules":[],"excludedRules":None,"customerConfig":None},{"ruleGroupId":"AWS#AWSManagedRulesSQLiRuleSet","terminatingRule":None,"nonTerminatingMatchingRules":[],"excludedRules":None,"customerConfig":None}],"rateBasedRuleList":[],"nonTerminatingMatchingRules":[],"requestHeadersInserted":None,"responseCodeSent":None,"httpRequest":{"clientIp":"1.2.3.4","country":"ES","headers":[{"name":"Host","value":"my-lb-123456.us-east-1.elb.amazonaws.com"},{"name":"User-Agent","value":"curl/7.79.1"},{"name":"Accept","value":"*/*"}],"uri":"/index.php","args":"","httpVersion":"HTTP/1.1","httpMethod":"GET","requestId":"1-636e94ac-0955431c62e36012512d103e"}}
+
+    expected_attributes = {
+        "aws.arn": 'arn:aws:wafv2:us-east-1:012345678910:regional/webacl/my-web-acl/5b291f89-a9c6-496f-bc56-28fe34178f25',
+        "audit.action": 'ALLOW',
+        "timestamp": 1668191404453
+    }
+
+    waf_processing_rule = processing_rules['aws']['waf']
+
+    def test_waf_attribute_extraction(self):
+        extracted_attributes = self.waf_processing_rule.get_extracted_log_attributes(self.waf_log_entry)
+        print(extracted_attributes)
+        self.assertEqual(extracted_attributes, self.expected_attributes)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -383,12 +383,12 @@ class TestVPCDNSquerylogs(unittest.TestCase):
         }
 
     expected_attributes = {
-        "timestamp": '2023-02-15T18:33:54Z'
-        #"aws.account.id": "012345678910",
-        #"aws.region": "us-east-1",
-        #"aws.resource.id": "vpc-0123456789abcdef12",
+        "timestamp": '2023-02-15T18:33:54Z',
+        "aws.account.id": "012345678910",
+        "aws.region": "us-east-1",
+        "aws.resource.id": "vpc-0123456789abcdef12",
         #"net.host.name": "ec2messages.us-east-1.amazonaws.com.",
-        #"severity": "INFO"
+        "severity": "INFO"
     }
 
     vpcdnsquery_processing_rule = processing_rules['aws']['vpcdnsquerylogs']

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -425,7 +425,7 @@ class testMSKLogs(unittest.TestCase):
         self.assertEqual(extracted_attributes,self.expected_attributes)
 
 class testGlobalAcceleratorLogs(unittest.TestCase):
-    log_entry = '2.0 512220559759 f0154cf1-4ac0-451b-87a2-5b2ce89142e6 1.2.3.4 57825 5.6.7.8 80 172.31.25.4 80 TCP IPV4 0 0 1676984801 1676984809 ACCEPT OK - 0 us-east-1 JFK6-2 INGRESS vpc-01234567891abcdef'
+    log_entry = '2.0 012345678910 f0154cf1-4ac0-451b-87a2-5b2ce89142e6 1.2.3.4 57825 5.6.7.8 80 172.31.25.4 80 TCP IPV4 0 0 1676984801 1676984809 ACCEPT OK - 0 us-east-1 JFK6-2 INGRESS vpc-01234567891abcdef'
 
     expected_attributes = {
         'timestamp': '1676984801'
@@ -435,6 +435,19 @@ class testGlobalAcceleratorLogs(unittest.TestCase):
 
     def test_global_accelerator_logs(self):
         extracted_attributes = self.global_accelerator_processing_rule.get_extracted_log_attributes(self.log_entry)
+        self.assertEqual(extracted_attributes,self.expected_attributes)
+
+class testVpcFlowLogs(unittest.TestCase):
+    log_entry = '2 012345678910 eni-02454058ae64a0b4e 172.31.6.100 67.220.242.48 59308 443 6 15 5338 1677665646 1677665674 ACCEPT OK'
+
+    expected_attributes = {
+        'timestamp': '1677665646'
+    }
+
+    vpc_flow_logs_processing_rule = processing_rules['aws']['vpcflowlogs']
+
+    def test_vpc_flow_logs(self):
+        extracted_attributes = self.vpc_flow_logs_processing_rule.get_extracted_log_attributes(self.log_entry)
         self.assertEqual(extracted_attributes,self.expected_attributes)
 
 class testCWLtoFirehoseLogs(unittest.TestCase):

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -93,7 +93,7 @@ class TestAWSAttributeInjection(unittest.TestCase):
 
     def test_vpcflowlog_attributes(self):
         expected_attributes = {
-            'log.source': 'fl-07f38b767c7cd46e3',
+            'aws.vpc.flow_log_id': 'fl-07f38b767c7cd46e3',
             'aws.account.id': '012345678910',
             'aws.region': 'us-east-1'
         }

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -25,36 +25,54 @@ cloudtrail_key_name = 'random_prefix/AWSLogs/012345678910/CloudTrail/us-east-1/2
 alb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_app.k8s-podinfo-podinfoi-ffbc3dc280.82a34fae168ba1aa_20220721T1440Z_192.168.122.18_3okvlwdx.log.gz'
 classic_elb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_a2e8277e0e09143fbb06db5dcd2a14c2_20220730T2350Z_192.168.36.65_31av101p.log'
 nlb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_net.k8s-podinfo-frontend-352ef7564b.809b86b470cfa0ff_20220927T1715Z_bbb0861d.log.gz'
-
-expected_attributes = {
-                        'aws.account.id': '012345678910',
-                        'aws.region': 'us-east-1'
-                      }
+waf_key_name = 'random_prefix/AWSLogs/012345678910/WAFLogs/eu-west-1/my-web-acl/2023/02/15/14/30/012345678910_waflogs_us-east-1_my-web-acl_20230215T1430Z_ec507835.log.gz'
+cloudfront_key_name = 'example/E1SFLUZKKLSP61.2023-02-16-14.e519cdee.gz'
+vpcflowlog_key_name = 'optional_prefix/AWSLogs/012345678910/vpcflowlogs/us-east-1/2023/02/14/012345678910_vpcflowlogs_us-east-1_fl-07f38b767c7cd46e3_20230214T0000Z_129a0cf7.log.gz'
+network_firewall_key_name = 'random_prefix/AWSLogs/012345678910/network-firewall/flow/us-east-1/my-test-firewall/2023/02/20/16/012345678910_network-firewall_flow_us-east-1_my-test-firewall_202302201610_e5c84094.log.gz'
+msk_key_name = 'AWSLogs/012345678910/KafkaBrokerLogs/us-east-1/demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20/2023-02-20-17/Broker-1_17-05_5b17f696.log.gz'
 
 class TestAWSAttributeInjection(unittest.TestCase):
     def test_cloudtrail_attributes(self):
         cloudtrail_processing_rule = processing_rules['aws']['CloudTrail']
+        expected_attributes = {
+                        'aws.account.id': '012345678910',
+                        'aws.region': 'us-east-1'
+                      }
+
         attributes = cloudtrail_processing_rule.get_attributes_from_s3_key_name(cloudtrail_key_name)
         self.assertEqual(attributes,expected_attributes)
 
     def test_alb_attributes(self):
         alb_processing_rule = processing_rules['aws']['ALB']
+        expected_attributes = {
+                        'aws.account.id': '012345678910',
+                        'aws.region': 'us-east-1'
+                      }
+
         attributes = alb_processing_rule.get_attributes_from_s3_key_name(alb_key_name)
         self.assertEqual(attributes,expected_attributes)
     
     def test_classic_attributes(self):
         classic_elb_processing_rule = processing_rules['aws']['Classic-ELB']
+        expected_attributes = {
+                        'aws.account.id': '012345678910',
+                        'aws.region': 'us-east-1'
+                      }
+
         attributes = classic_elb_processing_rule.get_attributes_from_s3_key_name(classic_elb_key_name)
         self.assertEqual(attributes,expected_attributes)
 
     def test_nlb_attributes(self):
         nlb_processing_rule = processing_rules['aws']['NLB']
+        expected_attributes = {
+                        'aws.account.id': '012345678910',
+                        'aws.region': 'us-east-1'
+                      }
+
         attributes = nlb_processing_rule.get_attributes_from_s3_key_name(nlb_key_name)
         self.assertEqual(attributes,expected_attributes)
 
     def test_waf_attributes(self):
-        waf_key_name = 'random_prefix/AWSLogs/012345678910/WAFLogs/eu-west-1/my-web-acl/2023/02/15/14/30/012345678910_waflogs_us-east-1_my-web-acl_20230215T1430Z_ec507835.log.gz'
-
         waf_processing_rule = processing_rules['aws']['waf']
         attributes = waf_processing_rule.get_attributes_from_s3_key_name(waf_key_name)
         expected_attributes = {
@@ -66,12 +84,84 @@ class TestAWSAttributeInjection(unittest.TestCase):
         self.assertEqual(attributes,expected_attributes)
 
     def test_cloudfront_attributes(self):
-        cloudfront_key_name = 'example/E1SFLUZKKLSP61.2023-02-16-14.e519cdee.gz'
         expected_attributes = {'aws.resource.id': 'E1SFLUZKKLSP61'}
         cloudfront_processing_rule = processing_rules['aws']['cloudfront']
         attributes = cloudfront_processing_rule.get_attributes_from_s3_key_name(cloudfront_key_name)
 
         self.assertEqual(attributes,expected_attributes)
+
+    def test_vpcflowlog_attributes(self):
+        expected_attributes = {
+            'log.source': 'fl-07f38b767c7cd46e3',
+            'aws.account.id': '012345678910',
+            'aws.region': 'us-east-1'
+        }
+
+        vpcflowlogs_processing_rule = processing_rules['aws']['vpcflowlogs']
+        attributes = vpcflowlogs_processing_rule.get_attributes_from_s3_key_name(vpcflowlog_key_name)
+
+        self.assertEqual(attributes,expected_attributes)
+    
+    def test_networkfirewall_attributes(self):
+        expected_attributes = {
+            'log.type': 'flow',
+            'aws.account.id': '012345678910',
+            'aws.region': 'us-east-1',
+            'aws.resource.id': 'my-test-firewall'
+        }
+
+        netfw_processing_rule = processing_rules['aws']['network-firewall']
+        attributes = netfw_processing_rule.get_attributes_from_s3_key_name(network_firewall_key_name)
+
+        self.assertEqual(attributes,expected_attributes)
+    
+    def test_msk_attributes(self):
+        expected_attributes = {
+            'aws.account.id': '012345678910',
+            'aws.region': 'us-east-1',
+            'aws.resource.id': 'demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20'
+        }
+
+        msk_processing_rule = processing_rules['aws']['msk']
+        attributes = msk_processing_rule.get_attributes_from_s3_key_name(msk_key_name)
+        self.assertEqual(attributes,expected_attributes)
+
+class TestS3KeyMatchingExpression(unittest.TestCase):
+
+    def test_cloudtrail_s3_key(self):
+        self.assertTrue(processing_rules['aws']['CloudTrail'].match_s3_key(cloudtrail_key_name))
+
+    def test_alb_s3_key(self):
+        self.assertTrue(processing_rules['aws']['ALB'].match_s3_key(alb_key_name))
+
+    def test_classic_elb_s3_key(self):
+        self.assertTrue(processing_rules['aws']['Classic-ELB'].match_s3_key(classic_elb_key_name))
+
+    def test_nlb_s3_key(self):
+        self.assertTrue(processing_rules['aws']['NLB'].match_s3_key(nlb_key_name))
+
+    def test_waf_s3_key(self):
+        self.assertTrue(processing_rules['aws']['waf'].match_s3_key(waf_key_name))
+
+    def test_cloudfront_s3_key(self):
+        self.assertTrue(processing_rules['aws']['cloudfront'].match_s3_key(cloudfront_key_name))
+
+    def test_vpcflowlogs_s3_key(self):
+        self.assertTrue(processing_rules['aws']['vpcflowlogs'].match_s3_key(vpcflowlog_key_name))
+    
+    def test_s3accesslogs_s3_key(self):
+        s3_key_name = 'optional-prefix/2022-10-03-10-13-50-A211246203787B7F'
+        self.assertTrue(processing_rules['aws']['s3'].match_s3_key(s3_key_name))
+    
+    def test_vpcdnsquerylogs_s3_key(self):
+        vpcdnsquerylog_key_name = 'OptionalPrefix/AWSLogs/012345678910/vpcdnsquerylogs/vpc-0123456789abcdf12/2023/02/15/vpc-0123456789abcdf12_vpcdnsquerylogs_012345678910_20230215T0000Z_213be99c.log.gz'
+        self.assertTrue(processing_rules['aws']['vpcdnsquerylogs'].match_s3_key(vpcdnsquerylog_key_name))
+    
+    def test_network_firewall_s3_key(self):
+        self.assertTrue(processing_rules['aws']['network-firewall'].match_s3_key(network_firewall_key_name))
+    
+    def test_msk_s3_key(self):
+        self.assertTrue(processing_rules['aws']['msk'].match_s3_key(msk_key_name))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -30,6 +30,7 @@ cloudfront_key_name = 'example/E1SFLUZKKLSP61.2023-02-16-14.e519cdee.gz'
 vpcflowlog_key_name = 'optional_prefix/AWSLogs/012345678910/vpcflowlogs/us-east-1/2023/02/14/012345678910_vpcflowlogs_us-east-1_fl-07f38b767c7cd46e3_20230214T0000Z_129a0cf7.log.gz'
 network_firewall_key_name = 'random_prefix/AWSLogs/012345678910/network-firewall/flow/us-east-1/my-test-firewall/2023/02/20/16/012345678910_network-firewall_flow_us-east-1_my-test-firewall_202302201610_e5c84094.log.gz'
 msk_key_name = 'AWSLogs/012345678910/KafkaBrokerLogs/us-east-1/demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20/2023-02-20-17/Broker-1_17-05_5b17f696.log.gz'
+global_accelerator_key_name = 'myprefix/AWSLogs/012345678910/globalaccelerator/us-west-2/2023/02/21/012345678910_globalaccelerator_f0154cf1-4ac0-451b-87a2-5b2ce89142e6_20230221T1305Z_2e13fabb.log.gz'
 
 class TestAWSAttributeInjection(unittest.TestCase):
     def test_cloudtrail_attributes(self):
@@ -126,6 +127,17 @@ class TestAWSAttributeInjection(unittest.TestCase):
         msk_processing_rule = processing_rules['aws']['msk']
         attributes = msk_processing_rule.get_attributes_from_s3_key_name(msk_key_name)
         self.assertEqual(attributes,expected_attributes)
+    
+    def test_global_accelerator_attributes(self):
+        expected_attributes = {
+            'aws.account.id': '012345678910',
+            'aws.region': 'us-west-2',
+            'aws.resource.id': 'f0154cf1-4ac0-451b-87a2-5b2ce89142e6'
+        }
+
+        global_accelerator_processing_rule = processing_rules['aws']['global-accelerator']
+        attributes = global_accelerator_processing_rule.get_attributes_from_s3_key_name(global_accelerator_key_name)
+        self.assertEqual(attributes,expected_attributes)
 
 class TestS3KeyMatchingExpression(unittest.TestCase):
 
@@ -163,6 +175,9 @@ class TestS3KeyMatchingExpression(unittest.TestCase):
     
     def test_msk_s3_key(self):
         self.assertTrue(processing_rules['aws']['msk'].match_s3_key(msk_key_name))
+
+    def test_global_accelerator_s3_key(self):
+        self.assertTrue(processing_rules['aws']['global-accelerator'].match_s3_key(global_accelerator_key_name))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -119,7 +119,8 @@ class TestAWSAttributeInjection(unittest.TestCase):
         expected_attributes = {
             'aws.account.id': '012345678910',
             'aws.region': 'us-east-1',
-            'aws.resource.id': 'demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20'
+            'aws.resource.id': 'demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20',
+            'aws.msk.broker': 'Broker-1'
         }
 
         msk_processing_rule = processing_rules['aws']['msk']

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -65,5 +65,13 @@ class TestAWSAttributeInjection(unittest.TestCase):
         
         self.assertEqual(attributes,expected_attributes)
 
+    def test_cloudfront_attributes(self):
+        cloudfront_key_name = 'example/E1SFLUZKKLSP61.2023-02-16-14.e519cdee.gz'
+        expected_attributes = {'aws.resource.id': 'E1SFLUZKKLSP61'}
+        cloudfront_processing_rule = processing_rules['aws']['cloudfront']
+        attributes = cloudfront_processing_rule.get_attributes_from_s3_key_name(cloudfront_key_name)
+
+        self.assertEqual(attributes,expected_attributes)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -21,11 +21,10 @@ os.environ['DEPLOYMENT_NAME'] = 'test'
 
 processing_rules, _ = log_processing_rules.load()
 
-cloudtrail_key_name = 'AWSLogs/012345678910/CloudTrail/us-east-1/2022/09/23/012345678910_CloudTrail_us-east-1_20220923T2350Z_noxkMtWv70h0LEES.json.gz'
-alb_key_name = 'AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_app.k8s-podinfo-podinfoi-ffbc3dc280.82a34fae168ba1aa_20220721T1440Z_192.168.122.18_3okvlwdx.log.gz'
-classic_elb_key_name = 'AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_a2e8277e0e09143fbb06db5dcd2a14c2_20220730T2350Z_192.168.36.65_31av101p.log'
-nlb_key_name = 'AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_net.k8s-podinfo-frontend-352ef7564b.809b86b470cfa0ff_20220927T1715Z_bbb0861d.log.gz'
-
+cloudtrail_key_name = 'random_prefix/AWSLogs/012345678910/CloudTrail/us-east-1/2022/09/23/012345678910_CloudTrail_us-east-1_20220923T2350Z_noxkMtWv70h0LEES.json.gz'
+alb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_app.k8s-podinfo-podinfoi-ffbc3dc280.82a34fae168ba1aa_20220721T1440Z_192.168.122.18_3okvlwdx.log.gz'
+classic_elb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_a2e8277e0e09143fbb06db5dcd2a14c2_20220730T2350Z_192.168.36.65_31av101p.log'
+nlb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_net.k8s-podinfo-frontend-352ef7564b.809b86b470cfa0ff_20220927T1715Z_bbb0861d.log.gz'
 
 expected_attributes = {
                         'aws.account.id': '012345678910',
@@ -53,6 +52,18 @@ class TestAWSAttributeInjection(unittest.TestCase):
         attributes = nlb_processing_rule.get_attributes_from_s3_key_name(nlb_key_name)
         self.assertEqual(attributes,expected_attributes)
 
+    def test_waf_attributes(self):
+        waf_key_name = 'random_prefix/AWSLogs/012345678910/WAFLogs/eu-west-1/my-web-acl/2023/02/15/14/30/012345678910_waflogs_us-east-1_my-web-acl_20230215T1430Z_ec507835.log.gz'
+
+        waf_processing_rule = processing_rules['aws']['waf']
+        attributes = waf_processing_rule.get_attributes_from_s3_key_name(waf_key_name)
+        expected_attributes = {
+                        'aws.account.id': '012345678910',
+                        'aws.region': 'eu-west-1',
+                        'aws.resource.id': 'my-web-acl'
+                      }
+        
+        self.assertEqual(attributes,expected_attributes)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/log/processing/rules/test_cwl_fh_s3_extraction.py
+++ b/tests/unit/log/processing/rules/test_cwl_fh_s3_extraction.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Dynatrace LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+import os
+from log.processing import log_processing_rules
+
+os.environ['LOG_FORWARDER_CONFIGURATION_LOCATION'] = 'local'
+os.environ['DEPLOYMENT_NAME'] = 'test'
+
+processing_rules, _ = log_processing_rules.load()
+
+
+class TestAttributeExtractionCWLFireHoseS3(unittest.TestCase):
+
+    def test_lambda_logs(self):
+
+        log_entry = {"aws.account.id": "012345678910", "aws.log_group": "/aws/lambda/hello-world-123",
+                     "aws.log_stream": "2023/02/14/[$LATEST]6c9e8a41d018497aa1f38fe84092c97b",
+                     "id": "37385399698484814707871715858877515407325547836143501312",
+                     "timestamp": 1676419301941, "message": "Hello World!"}
+
+        expected_attributes = {
+            "timestamp": 1676419301941,
+            "content": "Hello World!",
+            "aws.log_event_id": "37385399698484814707871715858877515407325547836143501312",
+            "aws.service": "lambda",
+            "aws.resource.id": "hello-world-123"
+        }
+
+        rule = processing_rules['custom']['cwl_to_fh']
+
+        extracted_attributes = rule.get_extracted_log_attributes(log_entry)
+
+        self.assertEqual(expected_attributes, extracted_attributes)
+
+    def test_eks_logs(self):
+
+        log_entry = {"aws.account.id": "012345678910", "aws.log_group": "/aws/eks/my_cluster/cluster",
+                    "aws.log_stream": "placeholder",
+                    "id": "37385399698484814707871715858877515407325547836143501312",
+                    "timestamp": 1676419301941, "message": "Hello World!"}
+
+        expected_attributes = {
+            "timestamp": 1676419301941,
+            "content": "Hello World!",
+            "aws.log_event_id": "37385399698484814707871715858877515407325547836143501312",
+            "aws.service": "eks",
+            "aws.resource.id": "my_cluster",
+            "log.source": "placeholder"
+        }
+
+        rule = processing_rules['custom']['cwl_to_fh']
+
+        for i in ["kube-apiserver", "kube-apiserver-audit", "authenticator",
+                    "kube-controller-manager", "kube-scheduler"]:
+
+            log_entry['aws.log_stream'] = i + \
+                "-1234567890abcdef01234567890abcde"
+
+            expected_attributes['log.source'] = i
+            extracted_attributes = rule.get_extracted_log_attributes(log_entry)
+
+            self.assertEqual(extracted_attributes, expected_attributes)

--- a/tests/unit/log/sinks/test_dynatrace.py
+++ b/tests/unit/log/sinks/test_dynatrace.py
@@ -74,11 +74,11 @@ class TestDynatraceSink(unittest.TestCase):
         num_messages_to_push = ceil(dynatrace.DYNATRACE_LOG_INGEST_PAYLOAD_MAX_SIZE / log_message_size) + 1
         
         responses.add(responses.POST, dynatrace_sink.get_environment_url() + dynatrace.LOGV2_API_URL_SUFFIX,
-                      body=json.dumps({'details': {'message': 'Success','code': 204}}).encode(dynatrace.ENCODING), 
+                      body=json.dumps({'details': {'message': 'Success','code': 204}}).encode(dynatrace.ENCODING),
                       content_type="application/json",
                       status=204)
 
-        for i in range(1,num_messages_to_push):
+        for _ in range(1,num_messages_to_push):
             dynatrace_sink.push(log_message)
 
         self.assertEqual(log_message_size,dynatrace_sink.get_size_of_buffered_messages())
@@ -97,7 +97,6 @@ class TestDynatraceSink(unittest.TestCase):
                       content_type="application/json",
                       status=429)
 
-        session = requests.Session()
         retry_strategy = Retry(
             total = 3,
             status_forcelist = [429],
@@ -110,7 +109,7 @@ class TestDynatraceSink(unittest.TestCase):
 
         session = requests.Session()
         session.mount("https://", adapter)
-        
+
         with self.assertRaises(MaxRetryError):
             dynatrace_sink.ingest_logs(test_log_entries,session=session)
 


### PR DESCRIPTION
**Features:**
Adds log processing rules for:
* AWS Global Accelerator
* Amazon Managed Streaming for Kafka
* AWS Network Firewall
* Amazon Redshift
* Amazon S3 
* Route 53 VPC resolver
* Amazon VPC Flow logs (default logs)
* AWS WAF

Also, adds support for attribute extraction of CloudWatch Logs -> Kinesis Firehose -> S3 for:
* AWS Lambda
* Amazon EKS control plane logs
* Amazon Route 53 public zone query logs

**Bug fixes:**
* ReceivedUncompressedLogFileSize metric calculation error

