### PR TITLE
bump dependencies versions

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,2 +1,2 @@
-moto==4.0.3
-responses==0.21.0
+moto==4.1.7
+responses==0.23.1

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,2 +1,2 @@
 moto==4.1.7
-responses==0.23.1
+responses==0.21.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.28.2
+requests==2.28.1
 jmespath==1.0.1
 pygrok==1.0.0
 PyYAML==6.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,10 @@
-requests==2.28.1
+requests==2.28.2
 jmespath==1.0.1
 pygrok==1.0.0
 PyYAML==6.0
-regex==2022.6.2
+regex==2023.3.23
 # aws-lambda-powertools 1.31.0 fixes a problem where metrics were lacking dimension
 # https://github.com/awslabs/aws-lambda-powertools-python/releases/tag/v1.31.0
-aws-lambda-powertools==2.6.0
-jsonslicer==0.1.7
+aws-lambda-powertools==2.14.0
+jsonslicer==0.1.8
 Jinja2==3.1.2

--- a/tests/unit/log/sinks/test_dynatrace.py
+++ b/tests/unit/log/sinks/test_dynatrace.py
@@ -110,8 +110,7 @@ class TestDynatraceSink(unittest.TestCase):
         session = requests.Session()
         session.mount("https://", adapter)
 
-        with self.assertRaises(MaxRetryError):
-            dynatrace_sink.ingest_logs(test_log_entries,session=session)
+        self.assertRaises(MaxRetryError,dynatrace_sink.ingest_logs,test_log_entries,session=session)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Bump dependencies versions:**
- aws-lambda-powertools==2.14.0
- jsonslicer==0.1.8
- moto==4.1.7