### PR TITLE
Pinned urllib3 version below 2.0.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,3 +8,6 @@ regex==2023.5.5
 aws-lambda-powertools==2.15.0
 jsonslicer==0.1.8
 Jinja2==3.1.2
+# botocore does not yet suport urllib3 in version 2.0.0 or higher. 
+# Check this ticket for more information: https://github.com/boto/botocore/issues/2926
+urllib3<2


### PR DESCRIPTION
Botocore does not yet support version 2.0.0 or higher of urllib3: https://github.com/boto/botocore/issues/2926. Therefore it was decided to pin urllib3 in order to avoid accidental installation of such versions.