### PR TITLE
Fix elbv2-id regex

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -31,7 +31,7 @@ helper_regexes = {
     'aws_region_pattern' : r'(us(-gov)?|ap|ca|cn|eu|sa|me|af)-(central|((north(east|west)?|south(east|west)?)|(east|west)))-\d{1}',
     'classic_load_balancer_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]',
     # ALB / NLB Load Balancer id can be up to 48 chars, and / is substituted with .,
-    'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,46}[a-zA-Z0-9]',
+    'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,47}[a-zA-Z0-9]',
     'ipv4_address_pattern' : r'(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',
     'aws_resource_name_pattern': r'[a-zA-Z0-9-_]{1,128}',
     'vpc_id_pattern': r'vpc-[0-9a-f]{8}(?:[0-9a-f]{9})?',


### PR DESCRIPTION
Fixes a bug on the regular expression identifying the elbv2-id when the ELB name length is 32 characters (max length). In this cases, log files are not recognized as ALB/NLB and are ingested as generic logs.