### PR TITLE
LOG-4535 limit sqs function trigger concurrency to prevent function throttling

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -122,7 +122,7 @@ Parameters:
   MaximumLambdaConcurrency:
     Description: Maximum number of Lambda functions running concurrently. The concurrency is reserved for the queue processing function, so it's guaranteed. 
     Type: Number
-    Default: 10
+    Default: 30
   LambdaSQSMessageBatchSize:
     Type: Number
     Description: Maximum number of messages to batch per each Queue Processing Lambda function execution

--- a/template.yaml
+++ b/template.yaml
@@ -122,7 +122,7 @@ Parameters:
   MaximumLambdaConcurrency:
     Description: Maximum number of Lambda functions running concurrently. The concurrency is reserved for the queue processing function, so it's guaranteed. 
     Type: Number
-    Default: 30
+    Default: 10
   LambdaSQSMessageBatchSize:
     Type: Number
     Description: Maximum number of messages to batch per each Queue Processing Lambda function execution
@@ -219,6 +219,8 @@ Resources:
             Queue: !GetAtt S3NotificationsQueue.Arn
             FunctionResponseTypes:
               - ReportBatchItemFailures
+            ScalingConfig:
+               MaximumConcurrency: !Ref MaximumLambdaConcurrency
       Policies:
         - SQSPollerPolicy:
             QueueName: !GetAtt S3NotificationsQueue.QueueName


### PR DESCRIPTION
1) Added `MaximumConcurrency` option to SQS trigger configuration and set to same value as `MaximumLambdaConcurrency`
See:
- https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-sqs.html#sam-function-sqs-scalingconfig
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-eventsourcemapping-scalingconfig.html

~~2) lowered default value of `MaximumLambdaConcurrency` to 10 to prevent overloading logs ingest endpoint in Dynatrace~~