### PR TITLE
add buildx plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 os: linux
 dist: jammy
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable'
+    packages:
+      - docker-buildx-plugin
 
 if: fork = false
 


### PR DESCRIPTION
Added docker buildx plugin using a way described in https://docs.travis-ci.com/user/reference/jammy/#third-party-apt-repositories-removed
That fixes build and gets rid of warning "...The legacy builder is deprecated and will be removed..."