### PR TITLE
fix: aws region pattern regex not matching il-central-1

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -28,7 +28,7 @@ helper_regexes = {
     'hour_pattern' : r'([0][0-9]|[1][0-9]|[2][0-3])',
     'minutes_pattern' : r'[0-5][0-9]',
     # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html,
-    'aws_region_pattern' : r'(us(-gov)?|ap|ca|cn|eu|sa|me|af)-(central|((north(east|west)?|south(east|west)?)|(east|west)))-\d{1}',
+    'aws_region_pattern' : r'(us(-gov)?|ap|ca|cn|eu|il|sa|me|af)-(central|((north(east|west)?|south(east|west)?)|(east|west)))-\d{1}',
     'classic_load_balancer_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]',
     # ALB / NLB Load Balancer id can be up to 48 chars, and / is substituted with .,
     'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,47}[a-zA-Z0-9]',

--- a/tests/unit/utils/test_regex.py
+++ b/tests/unit/utils/test_regex.py
@@ -1,0 +1,30 @@
+import re
+import unittest
+import boto3
+from utils.helpers import helper_regexes
+
+class TestHelperRegex(unittest.TestCase):
+
+    def test_aws_region(self):
+        
+        ssm_client = boto3.client('ssm',region_name='us-east-1')
+
+        paginator = ssm_client.get_paginator('get_parameters_by_path')
+
+        page_iterator = paginator.paginate(
+            Path='/aws/service/global-infrastructure/regions'
+        )
+
+        region_list = []
+        for page in page_iterator:
+            region_list += page['Parameters']
+
+        all_region_names = []
+        matched_region_names = []
+        for region in region_list:
+            all_region_names.append(region['Value'])
+            match = re.fullmatch(helper_regexes['aws_region_pattern'],region['Value'])
+            if match:
+                matched_region_names.append(region['Value'])
+
+        self.assertListEqual(all_region_names,matched_region_names)


### PR DESCRIPTION
**Bug fix:**

The `aws_region_pattern` helper regex doesn't match the il-central-1 region, making the log forwarder fail to match log processing rules using it (e.g. CloudTrail logs). 

- Amends the `aws_region_pattern` regex to match the Israel region
- Adds a unit test to validate all valid AWS regions match against the regex