### PR TITLE
Fix FMS/WAF Logs processing rule to process `cloudfront` waf logs

### DIFF
--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -19,7 +19,7 @@ name: waf
 # File Name example: AWSLogs/012345678910/WAFLogs/us-east-1/my-acl/2022/11/11/18/30/012345678910_waflogs_us-east-1_my-acl_20221111T1830Z_8e0a6094.log.gz
 # Hash string is 8 chars?
 
-known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/WAFLogs/{aws_region_pattern}/{aws_resource_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{minutes_pattern}/{aws_account_id_pattern}_(waflogs)_{aws_region_pattern}_{aws_resource_name_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
+known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/WAFLogs/{aws_fms_waf_region_pattern}/{aws_resource_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{minutes_pattern}/{aws_account_id_pattern}_(waflogs)_{aws_fms_waf_region_pattern}_{aws_resource_name_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
 source: aws
 
 log_format: json_stream
@@ -33,7 +33,7 @@ annotations:
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'
-  aws.region: '{aws_region_pattern}'
+  aws.region: '{aws_fms_waf_region_pattern}'
   # Get the value before /yyyy/mm/dd/HH/MM as the waf rule name
   aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
 

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -29,6 +29,8 @@ helper_regexes = {
     'minutes_pattern' : r'[0-5][0-9]',
     # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html,
     'aws_region_pattern' : r'(us(-gov)?|ap|ca|cn|eu|il|sa|me|af)-(central|((north(east|west)?|south(east|west)?)|(east|west)))-\d{1}',
+    # FMS logs have 'Cloudfront' as valid value in addition to all region names
+    'aws_fms_waf_region_pattern' : r'((us(-gov)?|ap|ca|cn|eu|il|sa|me|af)-(central|((north(east|west)?|south(east|west)?)|(east|west)))-\d{1}|cloudfront)',
     'classic_load_balancer_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]',
     # ALB / NLB Load Balancer id can be up to 48 chars, and / is substituted with .,
     'elbv2_id_pattern' : r'[a-zA-Z0-9][a-zA-Z0-9-.]{0,47}[a-zA-Z0-9]',


### PR DESCRIPTION
The AWS Firewall Manager (FMS) service stores WAF logs in S3 with object paths that include both standard AWS region names (e.g., ap-southeast-2) and the special case cloudfront. While the existing aws_region_pattern regex supports typical region identifiers, it excludes cloudfront—intentionally—since that pattern may also be used in contexts where strict region validation is required.

To address this without altering the original regex behavior, this change introduces a new pattern: aws_fms_waf_region_pattern.

This dedicated pattern is designed to explicitly support both region names and cloudfront, ensuring that all AWS WAF/FMS logs are accurately recognized and processed by the ingestion pipeline.