### PR TITLE
update LambdaInsightsExtension layers

### DIFF
--- a/get-required-lambda-layers.sh
+++ b/get-required-lambda-layers.sh
@@ -24,8 +24,8 @@ AWS_APPCONFIG_EXTENSION_ARM64="arn:aws:lambda:us-east-1:027255383542:layer:AWS-A
 
 # AWS Lambda Insights Extension
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versions.html
-AWS_LAMBDA_INSIGHTS_EXTENSION_X86_64="arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:35"
-AWS_LAMBDA_INSIGHTS_EXTENSION_ARM64="arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:2"
+AWS_LAMBDA_INSIGHTS_EXTENSION_X86_64="arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:64"
+AWS_LAMBDA_INSIGHTS_EXTENSION_ARM64="arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:31"
 
 download_layer() {
     aws lambda get-layer-version-by-arn --arn "$1" --query 'Content.Location' | xargs curl -s -o $BASE_DIR/"$2"/"$3"_extension.zip


### PR DESCRIPTION
Updating versions manually as the renovate detects need for update but has problems with branches that were created and deleted by me during initial testing:
"These problems occurred while renovating this repository. [View logs](https://developer.mend.io//github/dynatrace-oss/dynatrace-aws-s3-log-forwarder).

⚠️ WARN: Error updating branch: update failure"

Other two layers were successfully triggered by renovate in PRs https://github.com/dynatrace-oss/dynatrace-aws-s3-log-forwarder/pull/150 and https://github.com/dynatrace-oss/dynatrace-aws-s3-log-forwarder/pull/149
