### PR TITLE
Daq 22056 aws s 3 forwarder reduce log processing logic to minimal required

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -119,7 +119,6 @@ def lambda_handler(event, context):
         event_records = []
 
     for index, message in enumerate(event_records):
-
         # Empty the sinks in case some content was left due to errors and initialize
         # num_batch to 1.
         dynatrace.empty_sinks(dynatrace_sinks)

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -60,17 +60,17 @@ def _get_context_log_attributes(bucket: str, key: str):
     }
 
 
-def _get_filtered_output_message(attributes: dict) -> dict:
+def _get_output_message_with_reduced_fields(attributes: dict) -> dict:
     """Keep only attributes that should be sent to sinks."""
-    allowed_keys = {
+    allowed_keys = (
         'dt.da.aws.s3.bucket.name',
         'dt.da.aws.s3.key.name',
         'aws.arn',
         'aws.resource.type',
         'content',
         'timestamp',
-    }
-    return {k: v for k, v in attributes.items() if k in allowed_keys}
+    )
+    return {k: attributes.get(k) for k in allowed_keys}
 
 
 def _resolve_aws_arn_from_pattern(attributes: dict):
@@ -254,7 +254,7 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
                     _resolve_aws_arn_from_pattern(dt_log_message)
 
                     # Push to destination sink(s)
-                    dt_log_message = _get_filtered_output_message(dt_log_message)
+                    dt_log_message = _get_output_message_with_reduced_fields(dt_log_message)
                     for log_sink in log_sinks:
                         log_sink.push(dt_log_message)
 
@@ -319,7 +319,7 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
         _resolve_aws_arn_from_pattern(dt_log_message)
 
         # Push to destination sink(s)
-        output_message = _get_filtered_output_message(dt_log_message)
+        output_message = _get_output_message_with_reduced_fields(dt_log_message)
         for log_sink in log_sinks:
             log_sink.push(output_message)
 

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -16,7 +16,6 @@
 import logging
 import os
 import re
-from os import environ
 import sys
 import time
 import json
@@ -56,12 +55,22 @@ def _get_context_log_attributes(bucket: str, key: str):
     Returns context attributes to the log entry for troubleshooting purposes.
     '''
     return {
-        'log.source.aws.s3.bucket.name': bucket,
-        'log.source.aws.s3.key.name': key,
         'dt.da.aws.s3.bucket.name': bucket,
         'dt.da.aws.s3.key.name': key,
-        'cloud.log_forwarder': environ['FORWARDER_FUNCTION_ARN']
     }
+
+
+def _get_filtered_output_message(attributes: dict) -> dict:
+    """Keep only attributes that should be sent to sinks."""
+    allowed_keys = {
+        'dt.da.aws.s3.bucket.name',
+        'dt.da.aws.s3.key.name',
+        'aws.arn',
+        'aws.resource.type',
+        'content',
+        'timestamp',
+    }
+    return {k: v for k, v in attributes.items() if k in allowed_keys}
 
 
 def _resolve_aws_arn_from_pattern(attributes: dict):
@@ -80,7 +89,7 @@ def _resolve_aws_arn_from_pattern(attributes: dict):
         missing_keys.append(key)
         return match.group(0)
 
-    resolved_arn = re.sub(r'\{([^{}]+)\}', _replace, pattern)
+    resolved_arn = re.sub(r'\{([^{}]+)}', _replace, pattern)
 
     if missing_keys:
         logger.debug("Unable to resolve aws.arn.pattern. Missing attributes: %s", ','.join(sorted(set(missing_keys))))
@@ -134,7 +143,6 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
     s3_client = session.client('s3')
 
     log_obj_http_response = s3_client.get_object(Bucket=bucket, Key=key)
-
     log_obj_http_response_body = log_obj_http_response['Body']
     log_obj_http_response_content_encoding = log_obj_http_response.get('ContentEncoding', '').lower()
 
@@ -242,14 +250,11 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
                     dt_log_message.update(
                         log_processing_rule.get_extracted_log_attributes(sub_entry))
 
-                    # if the aws.region is not found, infer region from bucket
-                    if "aws.region" not in dt_log_message:
-                        dt_log_message['aws.region'] = bucket_region
-
                     # resolve ARN based on pattern
                     _resolve_aws_arn_from_pattern(dt_log_message)
 
                     # Push to destination sink(s)
+                    dt_log_message = _get_filtered_output_message(dt_log_message)
                     for log_sink in log_sinks:
                         log_sink.push(dt_log_message)
 
@@ -314,8 +319,9 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
         _resolve_aws_arn_from_pattern(dt_log_message)
 
         # Push to destination sink(s)
+        output_message = _get_filtered_output_message(dt_log_message)
         for log_sink in log_sinks:
-            log_sink.push(dt_log_message)
+            log_sink.push(output_message)
 
         num_log_entries += 1
 

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -246,6 +246,7 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
                     if "aws.region" not in dt_log_message:
                         dt_log_message['aws.region'] = bucket_region
 
+                    # resolve ARN based on pattern
                     _resolve_aws_arn_from_pattern(dt_log_message)
 
                     # Push to destination sink(s)

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import re
 from os import environ
 import sys
 import time
@@ -61,6 +62,31 @@ def _get_context_log_attributes(bucket: str, key: str):
         'dt.da.aws.s3.key.name': key,
         'cloud.log_forwarder': environ['FORWARDER_FUNCTION_ARN']
     }
+
+
+def _resolve_aws_arn_from_pattern(attributes: dict):
+    """Build aws.arn from aws.arn.pattern using the final merged attributes."""
+    pattern = attributes.pop('aws.arn.pattern', None)
+
+    if pattern is None or 'aws.arn' in attributes:
+        return
+
+    missing_keys = []
+
+    def _replace(match):
+        key = match.group(1)
+        if key in attributes:
+            return str(attributes[key])
+        missing_keys.append(key)
+        return match.group(0)
+
+    resolved_arn = re.sub(r'\{([^{}]+)\}', _replace, pattern)
+
+    if missing_keys:
+        logger.debug("Unable to resolve aws.arn.pattern. Missing attributes: %s", ','.join(sorted(set(missing_keys))))
+        return
+
+    attributes['aws.arn'] = resolved_arn
 
 
 def get_ijson_path_from_jmespath_path(jmespath_expr: str):
@@ -220,6 +246,8 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
                     if "aws.region" not in dt_log_message:
                         dt_log_message['aws.region'] = bucket_region
 
+                    _resolve_aws_arn_from_pattern(dt_log_message)
+
                     # Push to destination sink(s)
                     for log_sink in log_sinks:
                         log_sink.push(dt_log_message)
@@ -281,6 +309,8 @@ def process_log_object(log_processing_rule: LogProcessingRule, bucket: str, key:
         # if the aws.region is not found, infer region from bucket
         if "aws.region" not in dt_log_message:
             dt_log_message['aws.region'] = bucket_region
+
+        _resolve_aws_arn_from_pattern(dt_log_message)
 
         # Push to destination sink(s)
         for log_sink in log_sinks:

--- a/src/log/processing/processing.py
+++ b/src/log/processing/processing.py
@@ -57,6 +57,8 @@ def _get_context_log_attributes(bucket: str, key: str):
     return {
         'log.source.aws.s3.bucket.name': bucket,
         'log.source.aws.s3.key.name': key,
+        'dt.da.aws.s3.bucket.name': bucket,
+        'dt.da.aws.s3.key.name': key,
         'cloud.log_forwarder': environ['FORWARDER_FUNCTION_ARN']
     }
 

--- a/src/log/processing/rules/aws/alb.yaml
+++ b/src/log/processing/rules/aws/alb.yaml
@@ -29,6 +29,7 @@ annotations:
   cloud.provider: aws
   aws.service: alb
   aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/app/{aws.resource.id}"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy
 requester: 

--- a/src/log/processing/rules/aws/alb.yaml
+++ b/src/log/processing/rules/aws/alb.yaml
@@ -19,51 +19,17 @@ name: ALB
  # File Name: aws-account-id_elasticloadbalancing_region_app.load-balancer-id_end-time_ip-address_random-string.log.gz
  # Random string is 8 chars?
 known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(elasticloadbalancing)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(elasticloadbalancing)_{aws_region_pattern}_(app.){elbv2_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_{ipv4_address_pattern}_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
-
 source: aws
-
 log_format: text
 
+# Attribute extractions
 annotations:
-  log.source: aws.alb
-  cloud.provider: aws
-  aws.service: alb
   aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
-  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{aws.resource.id}"
-
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy
-requester: 
-  - "127311923021"
-  - "033677994240"
-  - "027434742980"
-  - "797873946194"
-  - "098369216593"
-  - "754344448648"
-  - "589379963580"
-  - "718504428378"
-  - "383597477331"
-  - "600734575887"
-  - "114774131450"
-  - "783225319266"
-  - "582318560864"
-  - "985666609251"
-  - "054676820928"
-  - "156460612806"
-  - "652711504416"
-  - "635631232127"
-  - "009996457667"
-  - "897822967062"
-  - "076674570225"
-  - "507241528517"
-  - "048591011584"
-  - "190560391635"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{elbv2_id}"
 
 attribute_extraction_from_key_name:
-  aws.account.id: '{aws_account_id_pattern}'
-  aws.region: '{aws_region_pattern}'
+  # needed for arn calculation
+  aws.region: "{aws_region_pattern}"
+  aws.account.id: "{aws_account_id_pattern}"
 
-attribute_extraction_grok_expression: '%{DATA:request_type} %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elbv2_id} %{IP:client_ip}:%{INT:client_port:int} (?:(%{IP:target_ip}:%{INT:target_port:int})|-) %{NUMBER:request_processing_time:float} %{NUMBER:target_processing_time:float} %{NUMBER:response_processing_time:float} %{INT:elb_status_code:int} (?:-|%{INT:target_status_code:int}) %{INT:received_bytes:int} %{INT:sent_bytes:int} "(?:(?<http_method>-|%{WORD:http_method})) %{URIPROTO:uriproto}://%{URIHOST:urihost}(?:-|%{URIPATH:uripath})(?:\?%{GREEDYDATA:uriparam})? (?:(?<http_version>-|%{NOTSPACE:http_version}))" "%{DATA:user_agent}" (?:-|%{DATA:ssl_cipher}) (?:-|%{DATA:ssl_protocol}) %{NOTSPACE:target_group_arn} "%{NOTSPACE:x_amzn_trace_id}" "(?:-|%{DATA:domain_name})" "(?:-|%{NOTSPACE:chosen_cert_arn})" (?:-|%{INT:matched_rule_priority}) %{TIMESTAMP_ISO8601:request_creation_time} "(?:-|%{NOTSPACE:actions_executed})" "(?:-|%{DATA:redirect_url})" "(?:-|%{DATA:error_reason})" "(?:-|%{GREEDYDATA:target_port_list})" "(?:-|%{GREEDYDATA:target_status_code_list})" "(?:-|%{DATA:classification})" "(?:-|%{DATA:classification_reason})"'
-
-attribute_extraction_jmespath_expression:
-  severity: "((elb_status_code.to_number(@) >= `400` && elb_status_code.to_number(@) < `500`) && 'WARN') || (elb_status_code.to_number(@) >= `500` && 'ERROR') || 'INFO'"
-  aws.resource.id: elbv2_id
+attribute_extraction_grok_expression: '%{NOTSPACE} %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elbv2_id} %{GREEDYDATA}'

--- a/src/log/processing/rules/aws/alb.yaml
+++ b/src/log/processing/rules/aws/alb.yaml
@@ -28,6 +28,7 @@ annotations:
   log.source: aws.alb
   cloud.provider: aws
   aws.service: alb
+  aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy
 requester: 

--- a/src/log/processing/rules/aws/alb.yaml
+++ b/src/log/processing/rules/aws/alb.yaml
@@ -29,7 +29,7 @@ annotations:
   cloud.provider: aws
   aws.service: alb
   aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
-  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/app/{aws.resource.id}"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{aws.resource.id}"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy
 requester: 

--- a/src/log/processing/rules/aws/appfabric.yaml
+++ b/src/log/processing/rules/aws/appfabric.yaml
@@ -22,6 +22,7 @@ log_format: json_stream
 annotations:
   cloud.provider: aws
   aws.service: appfabric
+  aws.resource.type: "AWS::AppFabric::Ingestion"
 
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:

--- a/src/log/processing/rules/aws/appfabric.yaml
+++ b/src/log/processing/rules/aws/appfabric.yaml
@@ -23,6 +23,7 @@ annotations:
   cloud.provider: aws
   aws.service: appfabric
   aws.resource.type: "AWS::AppFabric::Ingestion"
+  # aws.arn.patter: "arn:${Partition}:appfabric:${Region}:${Account}:appbundle/${AppbundleId}/ingestion/${IngestionIdentifier}"
 
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:

--- a/src/log/processing/rules/aws/appfabric.yaml
+++ b/src/log/processing/rules/aws/appfabric.yaml
@@ -20,14 +20,7 @@ source: aws
 log_format: json_stream
 
 annotations:
-  cloud.provider: aws
-  aws.service: appfabric
   aws.resource.type: "AWS::AppFabric::Ingestion"
-  # aws.arn.patter: "arn:${Partition}:appfabric:${Region}:${Account}:appbundle/${AppbundleId}/ingestion/${IngestionIdentifier}"
 
-# map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:
   timestamp: time
-  log.source: metadata.product.uid
-  audit.action: type_name
-  audit.identity: actor.user.email_addr

--- a/src/log/processing/rules/aws/classic-elb.yaml
+++ b/src/log/processing/rules/aws/classic-elb.yaml
@@ -24,6 +24,7 @@ annotations:
   log.source: aws.clb
   cloud.provider: aws
   aws.service: clb
+  aws.resource.type: "AWS::ElasticLoadBalancing::LoadBalancer"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
 requester: 

--- a/src/log/processing/rules/aws/classic-elb.yaml
+++ b/src/log/processing/rules/aws/classic-elb.yaml
@@ -21,45 +21,12 @@ source: aws
 log_format: text
 
 annotations:
-  log.source: aws.clb
-  cloud.provider: aws
-  aws.service: clb
   aws.resource.type: "AWS::ElasticLoadBalancing::LoadBalancer"
-  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{aws.resource.id}"
-
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
-requester: 
-  - "127311923021"
-  - "033677994240"
-  - "027434742980"
-  - "797873946194"
-  - "098369216593"
-  - "754344448648"
-  - "589379963580"
-  - "718504428378"
-  - "383597477331"
-  - "600734575887"
-  - "114774131450"
-  - "783225319266"
-  - "582318560864"
-  - "985666609251"
-  - "054676820928"
-  - "156460612806"
-  - "652711504416"
-  - "635631232127"
-  - "009996457667"
-  - "897822967062"
-  - "076674570225"
-  - "507241528517"
-  - "048591011584"
-  - "190560391635"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{elb_id}"
 
 attribute_extraction_from_key_name:
+  # needed for ARN calculation
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
 
-attribute_extraction_grok_expression: "%{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elb} %{IP:client_ip}:%{INT:client_port:int} (?:(%{IP:backend_ip}:?:%{INT:backend_port:int})|-) %{NUMBER:request_processing_time:float} %{NUMBER:backend_processing_time:float} %{NUMBER:response_processing_time:float} (?:-|%{INT:elb_status_code:int}) (?:-|%{INT:backend_status_code:int}) %{INT:received_bytes:int} %{INT:sent_bytes:int} \"%{ELB_REQUEST_LINE}\" \"(?:-|%{DATA:user_agent})\" (?:-|%{NOTSPACE:ssl_cipher}) (?:-|%{NOTSPACE:ssl_protocol})"
-
-attribute_extraction_jmespath_expression:
-   severity: "((elb_status_code.to_number(@) >= `400` && elb_status_code.to_number(@) < `500`) && 'WARN') || (elb_status_code.to_number(@) >= `500` && 'ERROR') || 'INFO'"
-   aws.resource.id: elb
+attribute_extraction_grok_expression: "%{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elb_id} %{GREEDYDATA}"

--- a/src/log/processing/rules/aws/classic-elb.yaml
+++ b/src/log/processing/rules/aws/classic-elb.yaml
@@ -25,6 +25,7 @@ annotations:
   cloud.provider: aws
   aws.service: clb
   aws.resource.type: "AWS::ElasticLoadBalancing::LoadBalancer"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{aws.resource.id}"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
 requester: 

--- a/src/log/processing/rules/aws/cloudfront.yaml
+++ b/src/log/processing/rules/aws/cloudfront.yaml
@@ -25,7 +25,6 @@ log_format: text
 
 annotations:
   aws.resource.type: "AWS::CloudFront::Distribution"
-  # aws.arn.pattern: "arn:{Partition}:cloudfront::${Account}:distribution/${DistributionId}"
 
 attribute_extraction_grok_expression: "%{CLOUDFRONTTIMESTAMP:timestamp_to_transform}"
 

--- a/src/log/processing/rules/aws/cloudfront.yaml
+++ b/src/log/processing/rules/aws/cloudfront.yaml
@@ -28,6 +28,7 @@ annotations:
   aws.service: cloudfront
   aws.region: global
   aws.resource.type: "AWS::CloudFront::Distribution"
+  # aws.arn.pattern: "arn:{Partition}:cloudfront::${Account}:distribution/${DistributionId}"
 
 attribute_extraction_from_key_name:
   aws.resource.id: '{cloudfront_distribution_id_pattern}(?=\.{year_pattern}-{month_pattern}-{day_pattern})'

--- a/src/log/processing/rules/aws/cloudfront.yaml
+++ b/src/log/processing/rules/aws/cloudfront.yaml
@@ -24,14 +24,8 @@ source: aws
 log_format: text
 
 annotations:
-  cloud.provider: aws
-  aws.service: cloudfront
-  aws.region: global
   aws.resource.type: "AWS::CloudFront::Distribution"
   # aws.arn.pattern: "arn:{Partition}:cloudfront::${Account}:distribution/${DistributionId}"
-
-attribute_extraction_from_key_name:
-  aws.resource.id: '{cloudfront_distribution_id_pattern}(?=\.{year_pattern}-{month_pattern}-{day_pattern})'
 
 attribute_extraction_grok_expression: "%{CLOUDFRONTTIMESTAMP:timestamp_to_transform}"
 

--- a/src/log/processing/rules/aws/cloudfront.yaml
+++ b/src/log/processing/rules/aws/cloudfront.yaml
@@ -27,6 +27,7 @@ annotations:
   cloud.provider: aws
   aws.service: cloudfront
   aws.region: global
+  aws.resource.type: "AWS::CloudFront::Distribution"
 
 attribute_extraction_from_key_name:
   aws.resource.id: '{cloudfront_distribution_id_pattern}(?=\.{year_pattern}-{month_pattern}-{day_pattern})'

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -25,6 +25,7 @@ annotations:
   cloud.provider: aws
   aws.service: cloudtrail
   aws.resource.type: "AWS::CloudTrail::Trail"
+  ###aws.arn.pattern: "arn:aws:cloudtrail:{aws.region}:{aws.account.id}:trail/{aws.resource.id}"
 
 requester:
   - cloudtrail.amazonaws.com

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -24,6 +24,7 @@ log_entries_key: Records
 annotations:
   cloud.provider: aws
   aws.service: cloudtrail
+  aws.resource.type: "AWS::CloudTrail::Trail"
 
 requester:
   - cloudtrail.amazonaws.com

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -23,7 +23,6 @@ log_entries_key: Records
 
 annotations:
   aws.resource.type: "AWS::CloudTrail::Trail"
-  ###aws.arn.pattern: "arn:aws:cloudtrail:{aws.region}:{aws.account.id}:trail/{aws.resource.id}"
 
 attribute_extraction_jmespath_expression:
   timestamp: eventTime

--- a/src/log/processing/rules/aws/cloudtrail.yaml
+++ b/src/log/processing/rules/aws/cloudtrail.yaml
@@ -22,32 +22,9 @@ log_format: json
 log_entries_key: Records
 
 annotations:
-  cloud.provider: aws
-  aws.service: cloudtrail
   aws.resource.type: "AWS::CloudTrail::Trail"
   ###aws.arn.pattern: "arn:aws:cloudtrail:{aws.region}:{aws.account.id}:trail/{aws.resource.id}"
 
-requester:
-  - cloudtrail.amazonaws.com
-
-attribute_extraction_from_key_name:
-  aws.account.id: '{aws_account_id_pattern}'
-  aws.region: '{aws_region_pattern}'
-  aws.organization.id: '{organization_id_pattern}'
-
-attribute_extraction_grok_expression:
-
 attribute_extraction_jmespath_expression:
   timestamp: eventTime
-  audit.event_source: eventSource
-  audit.action: eventName
-  audit.read_only: readOnly
-  audit.identity_type: "userIdentity.type || 'NotProvided'"
 
-  # Identity might be an ARN, an AWS Service or an AWS account Id
-  # (or principalId for WebIdentity user, e.g. Federated Users, Kubernetes IRSA)
-  audit.identity: "userIdentity.arn || userIdentity.invokedBy || userIdentity.principalId || userIdentity.accountId"
-  # if errorCode then Failed.errorCode, otherwise Succeed
-  audit.result: "errorCode && join('.', ['Failed', errorCode]) || 'Succeeded'"
-  # if errorCode exists -> ERROR, otherwise INFO
-  severity: "errorCode && 'ERROR' || 'INFO'"

--- a/src/log/processing/rules/aws/global-accelerator.yaml
+++ b/src/log/processing/rules/aws/global-accelerator.yaml
@@ -30,6 +30,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: global-accelerator
+  aws.resource.type: "AWS::GlobalAccelerator::Accelerator"
 
 
 attribute_extraction_from_key_name:

--- a/src/log/processing/rules/aws/global-accelerator.yaml
+++ b/src/log/processing/rules/aws/global-accelerator.yaml
@@ -19,28 +19,20 @@ name: global-accelerator
 # Format: s3-bucket_name/s3-bucket-prefix/AWSLogs/aws_account_id/globalaccelerator/region/yyyy/mm/dd/aws_account_id_globalaccelerator_accelerator_id_flow_log_id_timestamp_hash.log.gz
 # Example file name: optional_prefix/AWSLogs/123456789012/globalaccelerator/us-west-2/2018/11/23/123456789012_globalaccelerator_1234abcd-abcd-1234-abcd-1234abcdefgh_20181123T0005Z_1fb12345.log.gz
 known_key_path_pattern: '^.*?{aws_logs_prefix}\/{aws_account_id_pattern}\/(globalaccelerator)\/{aws_region_pattern}\/{year_pattern}/{month_pattern}/{day_pattern}\/{aws_account_id_pattern}_(globalaccelerator)_{aws_global_accelerator_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$'
-
 source: aws
-
 log_format: text
 
-requester:
-  - delivery.logs.amazonaws.com
-
 annotations:
-  cloud.provider: aws
-  aws.service: global-accelerator
   aws.resource.type: "AWS::GlobalAccelerator::Accelerator"
   aws.arn.pattern: "arn:aws:globalaccelerator::{aws.account.id}:accelerator/{aws.resource.id}"
 
-
 attribute_extraction_from_key_name:
+  # needed for ARN calculation
   aws.account.id: '{aws_account_id_pattern}'
-  aws.region: '{aws_region_pattern}'
   aws.resource.id: '{aws_global_accelerator_id_pattern}(?=_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$)'
 
 
 # https://docs.aws.amazon.com/global-accelerator/latest/dg/monitoring-global-accelerator.flow-logs.html#monitoring-global-accelerator.flow-logs.records.syntax
-attribute_extraction_grok_expression: '%{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE:timestamp} %{GREEDYDATA}'
+attribute_extraction_grok_expression: '^(?:\S+\s+){13}(?P<timestamp>\S+).*$'
 
 skip_header_lines: 1

--- a/src/log/processing/rules/aws/global-accelerator.yaml
+++ b/src/log/processing/rules/aws/global-accelerator.yaml
@@ -31,6 +31,7 @@ annotations:
   cloud.provider: aws
   aws.service: global-accelerator
   aws.resource.type: "AWS::GlobalAccelerator::Accelerator"
+  aws.arn.pattern: "arn:aws:globalaccelerator::{aws.account.id}:accelerator/{aws.resource.id}"
 
 
 attribute_extraction_from_key_name:

--- a/src/log/processing/rules/aws/msk.yaml
+++ b/src/log/processing/rules/aws/msk.yaml
@@ -24,8 +24,8 @@ log_format: text
 
 annotations:
   aws.resource.type: "AWS::MSK::Cluster"
+  # not sure
   aws.arn.pattern: "arn:aws:kafka:{aws.region}:{aws.account.id}:cluster/{aws.resource.id}"
-  # 	arn:{aws_partition}:kafka:{aws_region}:{aws_account_id}:cluster/{resource_name}/{aws_cluster_uuid}
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/msk.yaml
+++ b/src/log/processing/rules/aws/msk.yaml
@@ -19,17 +19,10 @@ name: msk
 # Example file name: AWSLogs/012345678910/KafkaBrokerLogs/us-east-1/demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20/2023-02-20-17/Broker-1_17-05_5b17f696.log.gz
 
 known_key_path_pattern: '^.*?{aws_logs_prefix}\/{aws_account_id_pattern}\/(KafkaBrokerLogs)/{aws_region_pattern}\/{aws_resource_name_pattern}\/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}\/(Broker)-\d{{1,3}}_{hour_pattern}-{minutes_pattern}_[a-fA-F0-9]{{8}}(\.log\.gz)$'
-
 source: aws
-
 log_format: text
 
-requester:
-  - delivery.logs.amazonaws.com
-
 annotations:
-  cloud.provider: aws
-  aws.service: msk
   aws.resource.type: "AWS::MSK::Cluster"
   aws.arn.pattern: "arn:aws:kafka:{aws.region}:{aws.account.id}:cluster/{aws.resource.id}"
   # 	arn:{aws_partition}:kafka:{aws_region}:{aws_account_id}:cluster/{resource_name}/{aws_cluster_uuid}
@@ -38,8 +31,6 @@ attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
   aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern})'
-  aws.msk.broker: '(Broker)-\d{{1,3}}(?=_{hour_pattern}-{minutes_pattern}_[a-fA-F0-9]{{8}}(\.log\.gz)$)'
 
-
-attribute_extraction_grok_expression: '\[%{TIMESTAMP_ISO8601:timestamp_to_transform}\] %{LOGLEVEL:severity}'
+attribute_extraction_grok_expression: '\[%{TIMESTAMP_ISO8601:timestamp_to_transform}\] %{GREEDYDATA}'
 

--- a/src/log/processing/rules/aws/msk.yaml
+++ b/src/log/processing/rules/aws/msk.yaml
@@ -30,6 +30,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: msk
+  aws.resource.type: "AWS::MSK::Cluster"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/msk.yaml
+++ b/src/log/processing/rules/aws/msk.yaml
@@ -31,6 +31,8 @@ annotations:
   cloud.provider: aws
   aws.service: msk
   aws.resource.type: "AWS::MSK::Cluster"
+  aws.arn.pattern: "arn:aws:kafka:{aws.region}:{aws.account.id}:cluster/{aws.resource.id}"
+  # 	arn:{aws_partition}:kafka:{aws_region}:{aws_account_id}:cluster/{resource_name}/{aws_cluster_uuid}
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/network-firewall.yaml
+++ b/src/log/processing/rules/aws/network-firewall.yaml
@@ -32,6 +32,7 @@ annotations:
   cloud.provider: aws
   aws.service: network-firewall
   aws.resource.type: "AWS::NetworkFirewall::Firewall"
+  aws.arn.pattern: "arn:aws:network-firewall:{aws.region}:{aws.account.id}:firewall/{aws.resource.id}"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/network-firewall.yaml
+++ b/src/log/processing/rules/aws/network-firewall.yaml
@@ -20,30 +20,20 @@ name: network-firewall
 # Example file name: AWSLogs/012345678910/network-firewall/flow/us-east-1/my-test-firewall/2023/02/20/16/012345678910_network-firewall_flow_us-east-1_my-test-firewall_202302201610_e5c84094.log.gz
 
 known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(network-firewall)/(alert|flow)/{aws_region_pattern}/{aws_resource_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{aws_account_id_pattern}_(network-firewall)_(alert|flow)_{aws_region_pattern}_{aws_resource_name_pattern}_{year_pattern}{month_pattern}{day_pattern}{hour_pattern}{minutes_pattern}_[a-fA-F0-9]{{8}}(\.log\.gz)$'
-
 source: aws
-
 log_format: json_stream
 
-requester:
-  - delivery.logs.amazonaws.com
-
 annotations:
-  cloud.provider: aws
-  aws.service: network-firewall
   aws.resource.type: "AWS::NetworkFirewall::Firewall"
   aws.arn.pattern: "arn:aws:network-firewall:{aws.region}:{aws.account.id}:firewall/{aws.resource.id}"
 
 attribute_extraction_from_key_name:
+  # for ARN calculation
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
-  # Should flow id be the log.source?
-  log.type: '(flow|alert)'
-  aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
 
 # https://docs.aws.amazon.com/network-firewall/latest/developerguide/firewall-logging.html#firewall-logging-contents
 # {"firewall_name":"test-firewall","availability_zone":"us-east-1b","event_timestamp":"1602627001","event":{"timestamp":"2020-10-13T22:10:01.006481+0000","flow_id":1582438383425873,"event_type":"alert","src_ip":"203.0.113.4","src_port":55555,"dest_ip":"192.0.2.16","dest_port":111,"proto":"TCP","alert":{"action":"allowed","signature_id":5,"rev":0,"signature":"test_tcp","category":"","severity":1}}}
 attribute_extraction_jmespath_expression:
-  #aws.resource.id: firewall_name
-  #aws.availability_zone: availability_zone
+  aws.resource.id: firewall_name
   timestamp: event_timestamp

--- a/src/log/processing/rules/aws/network-firewall.yaml
+++ b/src/log/processing/rules/aws/network-firewall.yaml
@@ -31,6 +31,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: network-firewall
+  aws.resource.type: "AWS::NetworkFirewall::Firewall"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/nlb.yaml
+++ b/src/log/processing/rules/aws/nlb.yaml
@@ -28,6 +28,7 @@ annotations:
   log.source: aws.nlb
   cloud.provider: aws
   aws.service: nlb
+  aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html#access-logging-bucket-requirements
 requester: 

--- a/src/log/processing/rules/aws/nlb.yaml
+++ b/src/log/processing/rules/aws/nlb.yaml
@@ -29,7 +29,7 @@ annotations:
   cloud.provider: aws
   aws.service: nlb
   aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
-  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/net/{aws.resource.id}"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{aws.resource.id}"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html#access-logging-bucket-requirements
 requester: 

--- a/src/log/processing/rules/aws/nlb.yaml
+++ b/src/log/processing/rules/aws/nlb.yaml
@@ -21,25 +21,14 @@ name: NLB
 # IMPORTANT: NLB Access Logs are only created if there's a TLS listener and they only contain information about TLS requests.
 known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(elasticloadbalancing)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{aws_account_id_pattern}_(elasticloadbalancing)_{aws_region_pattern}_(net\.){elbv2_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
 source: aws
-
 log_format: text
 
 annotations:
-  log.source: aws.nlb
-  cloud.provider: aws
-  aws.service: nlb
   aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
-  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{aws.resource.id}"
-
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html#access-logging-bucket-requirements
-requester: 
-  - delivery.logs.amazonaws.com
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/{elbv2_id}"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
 
-attribute_extraction_grok_expression: "%{WORD:listener_type} %{NOTSPACE:version} %{TIMESTAMP_ISO8601:timestamp} %{DATA:elb_id} %{DATA:listener} %{IP:client_ip}:%{INT:client_port} %{IP:destination_ip}:%{INT:destination_port} %{INT:connection_time} %{INT:tls_handshake_time} %{INT:received_bytes} %{INT:sent_bytes} (?:-|%{INT:incoming_tls_alert}) (?:-|%{DATA:chosen_cert_arn}) (?:-|%{DATA:chosen_cert_serial}) (?:-|%{DATA:tls_cipher}) (?:-|%{DATA:tls_protocol_version}) (?:-|%{DATA:tls_named_group}) (?:-|%{DATA:domain_name}) (?:-|%{DATA:alpn_fe_protocol}) (?:-|%{DATA:alpn_be_protocol}) (?:-|%{GREEDYDATA:alpn_client_preference_list})"
-
-attribute_extraction_jmespath_expression:
-  aws.resource.id: elb_id
+attribute_extraction_grok_expression: "%{WORD} %{NOTSPACE} %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elbv2_id} %{GREEDYDATA}"

--- a/src/log/processing/rules/aws/nlb.yaml
+++ b/src/log/processing/rules/aws/nlb.yaml
@@ -29,6 +29,7 @@ annotations:
   cloud.provider: aws
   aws.service: nlb
   aws.resource.type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
+  aws.arn.pattern: "arn:aws:elasticloadbalancing:{aws.region}:{aws.account.id}:loadbalancer/net/{aws.resource.id}"
 
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html#access-logging-bucket-requirements
 requester: 

--- a/src/log/processing/rules/aws/redshift.yaml
+++ b/src/log/processing/rules/aws/redshift.yaml
@@ -18,24 +18,15 @@ name: redshift
 # example log file: AWSLogs/123456789012/redshift/us-east-1/2013/10/29/123456789012_redshift_us-east-1_mycluster_userlog_2013-10-29T18:01.gz
 
 known_key_path_pattern: '^.*?{aws_logs_prefix}\/{aws_account_id_pattern}\/(redshift)/{aws_region_pattern}\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{aws_account_id_pattern}_redshift_{aws_region_pattern}_{redshift_cluster_name_pattern}_(userlog|connectionlog|useractivitylog)_{year_pattern}-{month_pattern}-{day_pattern}T{hour_pattern}:{minutes_pattern}(\.gz)$'
-
 source: aws
-
 log_format: text
 
-requester:
-  - redshift.amazonaws.com
-  # opt-in regions have region-specific service-principal: redshift.region.amazonaws.com
-
 annotations:
-  cloud.provider: aws
-  aws.service: redshift
   aws.resource.type: "AWS::Redshift::Cluster"
   aws.arn.pattern: "arn:aws:redshift:{aws.region}:{aws.account.id}:cluster:{aws.resource.id}"
 
 # https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-manage-log-files
 attribute_extraction_from_key_name:
-  log.source: '(connectionlog|userlog|useractivitylog)(?=_{year_pattern}-{month_pattern}-{day_pattern}T{hour_pattern}:{minutes_pattern}(\.gz)$)'
   aws.account.id: '{aws_account_id_pattern}'
   aws.region: '{aws_region_pattern}'
   aws.resource.id: '(?<=_){redshift_cluster_name_pattern}(?=_(connectionlog|userlog|useractivitylog)_{year_pattern}-{month_pattern}-{day_pattern}T{hour_pattern}:{minutes_pattern}(\.gz)$)'

--- a/src/log/processing/rules/aws/redshift.yaml
+++ b/src/log/processing/rules/aws/redshift.yaml
@@ -31,6 +31,7 @@ annotations:
   cloud.provider: aws
   aws.service: redshift
   aws.resource.type: "AWS::Redshift::Cluster"
+  aws.arn.pattern: "arn:aws:redshift:{aws.region}:{aws.account.id}:cluster:{aws.resource.id}"
 
 # https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-manage-log-files
 attribute_extraction_from_key_name:

--- a/src/log/processing/rules/aws/redshift.yaml
+++ b/src/log/processing/rules/aws/redshift.yaml
@@ -30,6 +30,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: redshift
+  aws.resource.type: "AWS::Redshift::Cluster"
 
 # https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-manage-log-files
 attribute_extraction_from_key_name:

--- a/src/log/processing/rules/aws/s3.yaml
+++ b/src/log/processing/rules/aws/s3.yaml
@@ -20,19 +20,11 @@ name: s3
 # Random string is 8 chars?
 known_key_path_pattern: '^.*?{year_pattern}-{month_pattern}-{day_pattern}-{hour_pattern}-{minutes_pattern}-{minutes_pattern}-[A-F0-9]{{16}}$'
 source: aws
-
 log_format: text
 
-requester:
-  - logging.s3.amazonaws.com
-
 annotations:
-  cloud.provider: aws
-  aws.service: s3
   aws.resource.type: "AWS::S3::Bucket"
-  aws.arn.pattern: "arn:aws:s3:::{aws.resource.id}"
+  aws.arn.pattern: "arn:aws:s3:::{bucket_name}"
 
 attribute_extraction_grok_expression: "%{DATA} %{DATA:bucket_name} \\[%{DATA:timestamp_to_transform}\\]"
 
-attribute_extraction_jmespath_expression:
-  aws.resource.id: bucket_name

--- a/src/log/processing/rules/aws/s3.yaml
+++ b/src/log/processing/rules/aws/s3.yaml
@@ -30,6 +30,7 @@ annotations:
   cloud.provider: aws
   aws.service: s3
   aws.resource.type: "AWS::S3::Bucket"
+  aws.arn.pattern: "arn:aws:s3:::{aws.resource.id}"
 
 attribute_extraction_grok_expression: "%{DATA} %{DATA:bucket_name} \\[%{DATA:timestamp_to_transform}\\]"
 

--- a/src/log/processing/rules/aws/s3.yaml
+++ b/src/log/processing/rules/aws/s3.yaml
@@ -29,6 +29,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: s3
+  aws.resource.type: "AWS::S3::Bucket"
 
 attribute_extraction_grok_expression: "%{DATA} %{DATA:bucket_name} \\[%{DATA:timestamp_to_transform}\\]"
 

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -18,18 +18,12 @@ name: vpcdnsquerylogs
 # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs.html
 # File name example: AWSLogs/012345678910/vpcdnsquerylogs/vpc-0123456789abcdf12/2023/02/15/vpc-0123456789abcdf12_vpcdnsquerylogs_012345678910_20230215T0000Z_213be99c.log.gz
 known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(vpcdnsquerylogs)/{vpc_id_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{vpc_id_pattern}_(vpcdnsquerylogs)_{aws_account_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$'
-
 source: aws
-
 log_format: json_stream
 
-requester:
-  - delivery.logs.amazonaws.com
 
 annotations:
-  log.source: aws.vpcdnsquerylogs
-  cloud.provider: aws
-  aws.service: route53
+  # not sure
   aws.resource.type: "AWS::EC2::VPC"
   # not sure
   aws.arn.pattern: "arn:aws:ec2:{aws.region}:{aws.account.id}:vpc/{aws.resource.id}"
@@ -40,5 +34,3 @@ attribute_extraction_jmespath_expression:
   aws.account.id: account_id
   aws.region: region
   aws.resource.id: vpc_id
-  #net.host.name: query_name
-  severity: "rcode == 'NOERROR' && 'INFO' || 'ERROR'"

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -31,6 +31,8 @@ annotations:
   cloud.provider: aws
   aws.service: route53
   aws.resource.type: "AWS::EC2::VPC"
+  # not sure
+  aws.arn.pattern: "arn:aws:ec2:{aws.region}:{aws.account.id}:vpc/{aws.resource.id}"
 
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:

--- a/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
+++ b/src/log/processing/rules/aws/vpcdnsquerylogs.yaml
@@ -30,6 +30,7 @@ annotations:
   log.source: aws.vpcdnsquerylogs
   cloud.provider: aws
   aws.service: route53
+  aws.resource.type: "AWS::EC2::VPC"
 
 # map message keys to DT LogsV2 API format  
 attribute_extraction_jmespath_expression:

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -20,17 +20,10 @@ name: vpcflowlogs
 # File name format: optional-prefix/AWSLogs/account_id/vpcflowlogs/region/year/month/day/(?hour/)aws_account_id_vpcflowlogs_region_flow_log_id_YYYYMMDDTHHmmZ_hash.log.gz
 # File name example: AWSLogs/012345678910/vpcflowlogs/us-east-1/2023/02/14/012345678910_vpcflowlogs_us-east-1_fl-07f38b767c7cd46e3_20230214T0000Z_129a0cf7.log.gz
 known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/(vpcflowlogs)/{aws_region_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/({hour_pattern}/)?{aws_account_id_pattern}_(vpcflowlogs)_{aws_region_pattern}_{vpc_flow_id_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-fA-F0-9]{{8}}(\.log\.gz)$'
-
 source: aws
-
 log_format: text
 
-requester:
-  - delivery.logs.amazonaws.com
-
 annotations:
-  cloud.provider: aws
-  aws.service: vpc
   # should it be marked as VPC or vpc flow log
   aws.resource.type: "AWS::EC2::VPC"
   aws.arn.pattern: "arn:aws:ec2:{aws.region}:{aws.account.id}:vpc-flow-log/{aws.vpc.flow_log_id}"
@@ -41,6 +34,6 @@ attribute_extraction_from_key_name:
   aws.vpc.flow_log_id: '{vpc_flow_id_pattern}'
 
 # Standar log format: version account-id interface-id srcaddr dstaddr srcport dstport protocol packets bytes start end action log-status
-attribute_extraction_grok_expression: '%{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE} %{NOTSPACE:timestamp} %{GREEDYDATA}'
+attribute_extraction_grok_expression: '^(?:\S+\s+){10}(?P<timestamp>\S+).*$'
 
 skip_header_lines: 1

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -31,8 +31,8 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: vpc
+  # should it be marked as VPC or vpc flow log
   aws.resource.type: "AWS::EC2::VPC"
-  # not sure
   aws.arn.pattern: "arn:aws:ec2:{aws.region}:{aws.account.id}:vpc-flow-log/{aws.vpc.flow_log_id}"
 
 attribute_extraction_from_key_name:

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -31,6 +31,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: vpc
+  aws.resource.type: "AWS::EC2::VPC"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/vpcflowlogs.yaml
+++ b/src/log/processing/rules/aws/vpcflowlogs.yaml
@@ -32,6 +32,8 @@ annotations:
   cloud.provider: aws
   aws.service: vpc
   aws.resource.type: "AWS::EC2::VPC"
+  # not sure
+  aws.arn.pattern: "arn:aws:ec2:{aws.region}:{aws.account.id}:vpc-flow-log/{aws.vpc.flow_log_id}"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -30,6 +30,7 @@ requester:
 annotations:
   cloud.provider: aws
   aws.service: wafv2
+  aws.resource.type: "AWS::WAFv2::WebACL"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -31,7 +31,6 @@ annotations:
   cloud.provider: aws
   aws.service: wafv2
   aws.resource.type: "AWS::WAFv2::WebACL"
-  # aws.arn.pattern: "arn:${Partition}:wafv2:${Region}:${Account}:${Scope}/webacl/${Name}/${Id}"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -31,6 +31,7 @@ annotations:
   cloud.provider: aws
   aws.service: wafv2
   aws.resource.type: "AWS::WAFv2::WebACL"
+  # aws.arn.pattern: "arn:${Partition}:wafv2:${Region}:${Account}:${Scope}/webacl/${Name}/${Id}"
 
 attribute_extraction_from_key_name:
   aws.account.id: '{aws_account_id_pattern}'

--- a/src/log/processing/rules/aws/waf.yaml
+++ b/src/log/processing/rules/aws/waf.yaml
@@ -21,24 +21,12 @@ name: waf
 
 known_key_path_pattern: '^.*?{aws_logs_prefix}/{aws_account_id_pattern}/WAFLogs/{aws_region_pattern}/{aws_resource_name_pattern}/{year_pattern}/{month_pattern}/{day_pattern}/{hour_pattern}/{minutes_pattern}/{aws_account_id_pattern}_(waflogs)_{aws_region_pattern}_{aws_resource_name_pattern}_{year_pattern}{month_pattern}{day_pattern}T{hour_pattern}{minutes_pattern}Z_[a-zA-Z0-9]{{8}}(\.log\.gz)$'
 source: aws
-
 log_format: json_stream
 
-requester:
-  - delivery.logs.amazonaws.com
 
 annotations:
-  cloud.provider: aws
-  aws.service: wafv2
   aws.resource.type: "AWS::WAFv2::WebACL"
-
-attribute_extraction_from_key_name:
-  aws.account.id: '{aws_account_id_pattern}'
-  aws.region: '{aws_region_pattern}'
-  # Get the value before /yyyy/mm/dd/HH/MM as the waf rule name
-  aws.resource.id: '{aws_resource_name_pattern}(?=\/{year_pattern}\/{month_pattern}\/{day_pattern}\/{hour_pattern}\/{minutes_pattern})'
 
 attribute_extraction_jmespath_expression:
   timestamp: timestamp
   aws.arn: webaclId
-  audit.action: action

--- a/src/log/processing/rules/custom/cwl-to-fh.yaml
+++ b/src/log/processing/rules/custom/cwl-to-fh.yaml
@@ -25,18 +25,7 @@ filter_json_objects_value: DATA_MESSAGE
 
 log_entries_key: logEvents
 
-annotations:
-  log.source: aws.cloudwatch_logs
-  cloud.provider: aws
-
-# From each JSON object within the stream, inherit the below attributes
-attribute_extraction_from_top_level_json:
-  owner: aws.account.id
-  logGroup: aws.log_group
-  logStream: aws.log_stream
-
-# map message keys to DT LogsV2 API format  
+# map message keys to DT LogsV2 API format
 attribute_extraction_jmespath_expression:
   timestamp: timestamp
   content: message
-  aws.log_event_id: id

--- a/tests/e2e/validate_logs_exist.py
+++ b/tests/e2e/validate_logs_exist.py
@@ -57,8 +57,8 @@ def get_logs_from_dynatrace(source_bucket_name,source_key_name):
 
     dql_query = (
         f'fetch logs'
-        f' | filter log.source.aws.s3.bucket.name == "{source_bucket_name}"'
-        f' AND log.source.aws.s3.key.name == "{source_key_name}"'
+        f' | filter dt.da.aws.s3.bucket.name == "{source_bucket_name}"'
+        f' AND dt.da.aws.s3.key.name == "{source_key_name}"'
         f' | limit 1'
     )
 

--- a/tests/unit/log/processing/rules/test_attribute_extraction.py
+++ b/tests/unit/log/processing/rules/test_attribute_extraction.py
@@ -67,13 +67,6 @@ class TestCloudTrailAttributeExtraction(unittest.TestCase):
 
     expected_attributes = {
                             "timestamp": cloudtrail_test_entry['eventTime'],
-                            "audit.event_source": cloudtrail_test_entry['eventSource'],
-                            "audit.action": cloudtrail_test_entry['eventName'],
-                            "audit.read_only": cloudtrail_test_entry['readOnly'],
-                            "audit.identity_type": cloudtrail_test_entry['userIdentity']['type'],
-                            "audit.identity": cloudtrail_test_entry['userIdentity']['arn'],
-                            "audit.result": "Succeeded",
-                            "severity": 'INFO'                          
                           }
 
     def test_cloudtrail_attribute_extraction(self):
@@ -85,35 +78,8 @@ class TestCloudTrailAttributeExtraction(unittest.TestCase):
 class TestALBAttributeExtraction(unittest.TestCase):
     alb_test_entry = 'http 2022-09-27T15:28:18.612792Z app/k8s-podinfo-podinfoi-ffbc3dc280/82a34fae168ba1aa 54.25.124.220:63763 192.168.15.219:9898 0.016 0.001 0.000 200 200 134 543 "GET http://k8s-podinfo-podinfoi-ffbc3dc280-1325129400.us-east-1.elb.amazonaws.com:80/ HTTP/1.1" "curl/7.79.1" - - arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/k8s-podinfo-frontend-b634dbe3b4/c0bcccc5dfc7c29c "Root=1-63331692-0dd6b14130c01d3e378a6ea5" "-" "-" 1 2022-09-27T15:28:18.565000Z "forward" "-" "-" "192.168.15.219:9898" "200" "-" "-"'
     expected_attributes = {
-                            'request_type': 'http',
                             'timestamp': '2022-09-27T15:28:18.612792Z',
-                            'client_ip': '54.25.124.220',
-                            'client_port': 63763,
-                            'target_ip': '192.168.15.219',
-                            'target_port': 9898,
-                            'request_processing_time': 0.016,
-                            'target_processing_time': 0.001,
-                            'response_processing_time': 0.0,
-                            'elb_status_code': 200,
-                            'target_status_code': 200,
-                            'received_bytes': 134,
-                            'sent_bytes': 543,
-                            'http_method': 'GET',
-                            'uriproto': 'http',
-                            'urihost': 'k8s-podinfo-podinfoi-ffbc3dc280-1325129400.us-east-1.elb.amazonaws.com:80',
-                            'port': '80',
-                            'uripath': '/',
-                            'http_version': 'HTTP/1.1',
-                            'user_agent': 'curl/7.79.1',
-                            'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-1:012345678910:targetgroup/k8s-podinfo-frontend-b634dbe3b4/c0bcccc5dfc7c29c',
-                            'x_amzn_trace_id': 'Root=1-63331692-0dd6b14130c01d3e378a6ea5',
-                            'matched_rule_priority': '1',
-                            'request_creation_time': '2022-09-27T15:28:18.565000Z',
-                            'actions_executed': 'forward',
-                            'target_port_list': '192.168.15.219:9898',
-                            'target_status_code_list': '200',
-                            'severity': 'INFO',
-                            'aws.resource.id': 'app/k8s-podinfo-podinfoi-ffbc3dc280/82a34fae168ba1aa'
+                            'elbv2_id': 'app/k8s-podinfo-podinfoi-ffbc3dc280/82a34fae168ba1aa',
                          }
     alb_processing_rule = processing_rules['aws']['ALB']
 
@@ -123,253 +89,65 @@ class TestALBAttributeExtraction(unittest.TestCase):
     
     def test_alb_attribute_extraction_http(self):
         log_entry = 'http 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.000 0.001 0.000 200 200 34 366 "GET http://www.example.com:80/ HTTP/1.1" "curl/7.46.0" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337262-36d228ad5d99923122bbe354" "-" "-" 0 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
-        expected_attributes = { 'request_type': 'http',
-                                'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'client_ip': '192.168.131.39',
-                                'client_port': 2817,
-                                'target_ip': '10.0.0.1',
-                                'target_port': 80,
-                                'request_processing_time': 0.0,
-                                'target_processing_time': 0.001,
-                                'response_processing_time': 0.0,
-                                'elb_status_code': 200,
-                                'target_status_code': 200,
-                                'received_bytes': 34,
-                                'sent_bytes': 366,
-                                'http_method': 'GET',
-                                'uriproto': 'http',
-                                'urihost': 'www.example.com:80',
-                                'port': '80',
-                                'uripath': '/',
-                                'http_version': 'HTTP/1.1',
-                                'user_agent': 'curl/7.46.0',
-                                'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                                'x_amzn_trace_id': 'Root=1-58337262-36d228ad5d99923122bbe354',
-                                'matched_rule_priority': '0',
-                                'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                                'actions_executed': 'forward',
-                                'target_port_list': '10.0.0.1:80',
-                                'target_status_code_list': '200',
-                                'severity': 'INFO',
-                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
-                            }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
 
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
 
     def test_alb_attribute_extraction_https(self):
         log_entry = 'https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.086 0.048 0.037 200 200 0 57 "GET https://www.example.com:443/ HTTP/1.1" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337281-1d84f3d73c47ec4e58577259" "www.example.com" "arn:aws:acm:us-east-2:123456789012:certificate/12345678-1234-1234-1234-123456789012" 1 2018-07-02T22:22:48.364000Z "authenticate,forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
-        expected_attributes = { 'request_type': 'https',
-                                'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'client_ip': '192.168.131.39',
-                                'client_port': 2817,
-                                'target_ip': '10.0.0.1',
-                                'target_port': 80,
-                                'request_processing_time': 0.086,
-                                'target_processing_time': 0.048,
-                                'response_processing_time': 0.037,
-                                'elb_status_code': 200,
-                                'target_status_code': 200,
-                                'received_bytes': 0,
-                                'sent_bytes': 57,
-                                'http_method': 'GET',
-                                'uriproto': 'https',
-                                'urihost': 'www.example.com:443',
-                                'port': '443',
-                                'uripath': '/',
-                                'http_version': 'HTTP/1.1',
-                                'user_agent': 'curl/7.46.0',
-                                'ssl_cipher': 'ECDHE-RSA-AES128-GCM-SHA256',
-                                'ssl_protocol': 'TLSv1.2',
-                                'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                                'x_amzn_trace_id': 'Root=1-58337281-1d84f3d73c47ec4e58577259',
-                                'domain_name': 'www.example.com',
-                                'chosen_cert_arn': 'arn:aws:acm:us-east-2:123456789012:certificate/12345678-1234-1234-1234-123456789012',
-                                'matched_rule_priority': '1',
-                                'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                                'actions_executed': 'authenticate,forward',
-                                'target_port_list': '10.0.0.1:80',
-                                'target_status_code_list': '200',
-                                'severity': 'INFO',
-                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
-                            }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
 
     def test_alb_attribute_extraction_http2(self):
         log_entry = 'h2 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.1.252:48160 10.0.0.66:9000 0.000 0.002 0.000 200 200 5 257 "GET https://10.0.2.105:773/ HTTP/2.0" "curl/7.46.0" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337327-72bd00b0343d75b906739c42" "-" "-" 1 2018-07-02T22:22:48.364000Z "redirect" "https://example.com:80/" "-" "10.0.0.66:9000" "200" "-" "-"'
-        expected_attributes = { 'request_type': 'h2', 
-                                'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'client_ip': '10.0.1.252',
-                                'client_port': 48160,
-                                'target_ip': '10.0.0.66',
-                                'target_port': 9000,
-                                'request_processing_time': 0.0,
-                                'target_processing_time': 0.002,
-                                'response_processing_time': 0.0,
-                                'elb_status_code': 200,
-                                'target_status_code': 200,
-                                'received_bytes': 5,
-                                'sent_bytes': 257,
-                                'http_method': 'GET',
-                                'uriproto': 'https',
-                                'urihost': '10.0.2.105:773',
-                                'port': '773',
-                                'uripath': '/',
-                                'http_version': 'HTTP/2.0',
-                                'user_agent': 'curl/7.46.0',
-                                'ssl_cipher': 'ECDHE-RSA-AES128-GCM-SHA256',
-                                'ssl_protocol': 'TLSv1.2',
-                                'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                                'x_amzn_trace_id': 'Root=1-58337327-72bd00b0343d75b906739c42',
-                                'matched_rule_priority': '1',
-                                'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                                'actions_executed': 'redirect',
-                                'redirect_url': 'https://example.com:80/',
-                                'target_port_list': '10.0.0.66:9000',
-                                'target_status_code_list': '200',
-                                'severity': 'INFO',
-                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188' }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
     
     def test_alb_attribute_extraction_ws(self):
         log_entry = 'ws 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.0.140:40914 10.0.1.192:8010 0.001 0.003 0.000 101 101 218 587 "GET http://10.0.0.30:80/ HTTP/1.1" "-" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-" 1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.1.192:8010" "101" "-" "-"'
-        expected_attributes = { 'request_type': 'ws',
-                                'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'client_ip': '10.0.0.140',
-                                'client_port': 40914,
-                                'target_ip': '10.0.1.192',
-                                'target_port': 8010,
-                                'request_processing_time': 0.001,
-                                'target_processing_time': 0.003,
-                                'response_processing_time': 0.0,
-                                'elb_status_code': 101,
-                                'target_status_code': 101,
-                                'received_bytes': 218,
-                                'sent_bytes': 587,
-                                'http_method': 'GET',
-                                'uriproto': 'http',
-                                'urihost': '10.0.0.30:80',
-                                'port': '80',
-                                'uripath': '/',
-                                'http_version': 'HTTP/1.1',
-                                'user_agent': '-',
-                                'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                                'x_amzn_trace_id': 'Root=1-58337364-23a8c76965a2ef7629b185e3',
-                                'matched_rule_priority': '1',
-                                'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                                'actions_executed': 'forward',
-                                'target_port_list': '10.0.1.192:8010',
-                                'target_status_code_list': '101',
-                                'severity': 'INFO',
-                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
-                            }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
 
     def test_alb_attribute_extraction_no_http_method(self):
         log_entry = 'https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.0.140:40914 10.0.1.192:8010 0.001 0.003 0.000 101 101 218 587 "- http://10.0.0.30:80/ HTTP/1.1" "-" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-" 1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.1.192:8010" "101" "-" "-"'
-        expected_attributes = { 'request_type': 'https',
-                                'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'client_ip': '10.0.0.140',
-                                'client_port': 40914,
-                                'target_ip': '10.0.1.192',
-                                'target_port': 8010,
-                                'request_processing_time': 0.001,
-                                'target_processing_time': 0.003,
-                                'response_processing_time': 0.0,
-                                'elb_status_code': 101,
-                                'target_status_code': 101,
-                                'received_bytes': 218,
-                                'sent_bytes': 587,
-                                'http_method': '-',
-                                'uriproto': 'http',
-                                'urihost': '10.0.0.30:80',
-                                'port': '80',
-                                'uripath': '/',
-                                'http_version': 'HTTP/1.1',
-                                'user_agent': '-',
-                                'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                                'x_amzn_trace_id': 'Root=1-58337364-23a8c76965a2ef7629b185e3',
-                                'matched_rule_priority': '1',
-                                'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                                'actions_executed': 'forward',
-                                'target_port_list': '10.0.1.192:8010',
-                                'target_status_code_list': '101',
-                                'severity': 'INFO',
-                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
-                            }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
 
     def test_alb_attribute_extraction_dash_instead_of_path(self):
         log_entry = 'https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.0.140:40914 10.0.1.192:8010 0.001 0.003 0.000 101 101 218 587 "- http://10.0.0.30:80- -" "-" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-" 1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.1.192:8010" "101" "-" "-"'
-        expected_attributes = {'request_type': 'https',
-                               'timestamp': '2018-07-02T22:23:00.186641Z',
-                               'client_ip': '10.0.0.140',
-                               'client_port': 40914,
-                               'target_ip': '10.0.1.192',
-                               'target_port': 8010,
-                               'request_processing_time': 0.001,
-                               'target_processing_time': 0.003,
-                               'response_processing_time': 0.0,
-                               'elb_status_code': 101,
-                               'target_status_code': 101,
-                               'received_bytes': 218,
-                               'sent_bytes': 587,
-                               'http_method': '-',
-                               'uriproto': 'http',
-                               'urihost': '10.0.0.30:80',
-                               'port': '80',
-                               'http_version': '-',
-                               'user_agent': '-',
-                               'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                               'x_amzn_trace_id': 'Root=1-58337364-23a8c76965a2ef7629b185e3',
-                               'matched_rule_priority': '1',
-                               'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                               'actions_executed': 'forward',
-                               'target_port_list': '10.0.1.192:8010',
-                               'target_status_code_list': '101',
-                               'severity': 'INFO',
-                               'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
-                               }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes, extracted_attributes)
 
     def alb_attribute_extraction_complicated_uri_param_base_test(self, uriparam):
         log_entry = f'https 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 10.0.0.140:40914 10.0.1.192:8010 0.001 0.003 0.000 101 101 218 587 "POST http://10.0.0.30:80/index.php?{uriparam} HTTP/1.1" "-" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337364-23a8c76965a2ef7629b185e3" "-" "-" 1 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.1.192:8010" "101" "-" "-"'
-        expected_attributes = { 'request_type': 'https',
-                                'timestamp': '2018-07-02T22:23:00.186641Z',
-                                'client_ip': '10.0.0.140',
-                                'client_port': 40914,
-                                'target_ip': '10.0.1.192',
-                                'target_port': 8010,
-                                'request_processing_time': 0.001,
-                                'target_processing_time': 0.003,
-                                'response_processing_time': 0.0,
-                                'elb_status_code': 101,
-                                'target_status_code': 101,
-                                'received_bytes': 218,
-                                'sent_bytes': 587,
-                                'http_method': 'POST',
-                                'uriproto': 'http',
-                                'urihost': '10.0.0.30:80',
-                                'port': '80',
-                                'uripath': '/index.php',
-                                'uriparam': uriparam,
-                                'http_version': 'HTTP/1.1',
-                                'user_agent': '-',
-                                'target_group_arn': 'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067',
-                                'x_amzn_trace_id': 'Root=1-58337364-23a8c76965a2ef7629b185e3',
-                                'matched_rule_priority': '1',
-                                'request_creation_time': '2018-07-02T22:22:48.364000Z',
-                                'actions_executed': 'forward',
-                                'target_port_list': '10.0.1.192:8010',
-                                'target_status_code_list': '101',
-                                'severity': 'INFO',
-                                'aws.resource.id': 'app/my-loadbalancer/50dc6c495c0c9188'
-                            }
+        expected_attributes = {
+            'timestamp': '2018-07-02T22:23:00.186641Z',
+            'elbv2_id': 'app/my-loadbalancer/50dc6c495c0c9188'
+        }
         extracted_attributes = self.alb_processing_rule.get_extracted_log_attributes(log_entry)
         self.assertEqual(expected_attributes,extracted_attributes)
 
@@ -385,29 +163,8 @@ class TestALBAttributeExtraction(unittest.TestCase):
 
 class TestClassicELBAttributeExtraction(unittest.TestCase):
     classic_elb_test_entry = '2022-09-27T22:48:26.330387Z a2e8277e0e09143fbb06db5dcd2a14c2 3.67.7.163:8596 192.168.18.161:32728 0.000042 0.004504 0.000036 404 404 0 1086 "GET http://a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80/n9BxiYVakde9.php HTTP/1.1" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)" - -'
-    expected_attributes = { "timestamp": "2022-09-27T22:48:26.330387Z",
-                            "client_ip": "3.67.7.163",
-                            "client_port": 8596,
-                            "backend_ip": "192.168.18.161",
-                            "backend_port": 32728,
-                            "request_processing_time": 4.2e-05,
-                            "backend_processing_time": 0.004504,
-                            "response_processing_time": 3.6e-05,
-                            "elb_status_code": 404,
-                            "backend_status_code": 404,
-                            "received_bytes": 0,
-                            "sent_bytes": 1086,
-                            "verb": "GET",
-                            "request": "http://a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80/n9BxiYVakde9.php",
-                            "proto": "http",
-                            "urihost": "a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80",
-                            "port": "80",
-                            "path": "/n9BxiYVakde9.php",
-                            "httpversion": "1.1",
-                            "user_agent": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)",
-                            "severity": "WARN",
-                            "aws.resource.id": "a2e8277e0e09143fbb06db5dcd2a14c2"
-                          }
+    expected_attributes = {"timestamp": "2022-09-27T22:48:26.330387Z",
+                           "elb_id": "a2e8277e0e09143fbb06db5dcd2a14c2",}
 
     classic_elb_processing_rule = processing_rules['aws']['Classic-ELB']
 
@@ -418,24 +175,8 @@ class TestClassicELBAttributeExtraction(unittest.TestCase):
 
 class TestNLBAttributeExtraction(unittest.TestCase):
     nlb_test_entry = 'tls 2.0 2022-09-27T17:10:23 net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff f0f22c45225e4663 192.168.18.161:60808 192.168.103.168:443 24 16 140 518 - arn:aws:acm:us-east-1:012345678910:certificate/ae6e87cd-9848-465b-9433-b0d34850a685 - ECDHE-RSA-AES128-GCM-SHA256 tlsv12 - k8s-podinfo-frontend-352ef7564b-809b86b470cfa0ff.elb.us-east-1.amazonaws.com - - -'
-    expected_attributes = { 'listener_type': 'tls',
-                            'version': '2.0',
-                            'timestamp': '2022-09-27T17:10:23',
-                            'listener': 'f0f22c45225e4663',
-                            'client_ip': '192.168.18.161',
-                            'client_port': '60808',
-                            'destination_ip': '192.168.103.168',
-                            'destination_port': '443',
-                            'connection_time': '24',
-                            'tls_handshake_time': '16',
-                            'received_bytes': '140',
-                            'sent_bytes': '518',
-                            'chosen_cert_arn': 'arn:aws:acm:us-east-1:012345678910:certificate/ae6e87cd-9848-465b-9433-b0d34850a685',
-                            'tls_cipher': 'ECDHE-RSA-AES128-GCM-SHA256',
-                            'tls_protocol_version': 'tlsv12',
-                            'domain_name': 'k8s-podinfo-frontend-352ef7564b-809b86b470cfa0ff.elb.us-east-1.amazonaws.com',
-                            'aws.resource.id': 'net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff'
-                        }
+    expected_attributes = {'timestamp': '2022-09-27T17:10:23',
+                           'elbv2_id': 'net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff',}
     nlb_processing_rule = processing_rules['aws']['NLB']
 
     def test_nlb_attribute_extraction(self):
@@ -445,10 +186,7 @@ class TestNLBAttributeExtraction(unittest.TestCase):
 class TestS3AccessLogsAttributeExtraction(unittest.TestCase):
     s3_access_log_entry = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be DOC-EXAMPLE-BUCKET1 [06/Feb/2019:00:00:38 +0000] 192.0.2.3 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE REST.GET.VERSIONING - "GET /DOC-EXAMPLE-BUCKET1?versioning HTTP/1.1" 200 - 113 - 7 - "-" "S3Console/0.4" - s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234= SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader DOC-EXAMPLE-BUCKET1.s3.us-west-1.amazonaws.com TLSV1.2 arn:aws:s3:us-west-1:123456789012:accesspoint/example-AP Yes'
 
-    expected_attributes = {
-        'aws.resource.id': 'DOC-EXAMPLE-BUCKET1',
-        'timestamp': '2019-02-06T00:00:38+00:00'
-    }
+    expected_attributes = {'bucket_name': 'DOC-EXAMPLE-BUCKET1', 'timestamp': '2019-02-06T00:00:38+00:00'}
 
     s3_processing_rule = processing_rules['aws']['s3']
 
@@ -461,7 +199,6 @@ class TestWAFLogAttributeExtraction(unittest.TestCase):
 
     expected_attributes = {
         "aws.arn": 'arn:aws:wafv2:us-east-1:012345678910:regional/webacl/my-web-acl/5b291f89-a9c6-496f-bc56-28fe34178f25',
-        "audit.action": 'ALLOW',
         "timestamp": 1668191404453
     }
 
@@ -502,8 +239,6 @@ class TestVPCDNSquerylogs(unittest.TestCase):
         "aws.account.id": "012345678910",
         "aws.region": "us-east-1",
         "aws.resource.id": "vpc-0123456789abcdef12",
-        #"net.host.name": "ec2messages.us-east-1.amazonaws.com.",
-        "severity": "INFO"
     }
 
     vpcdnsquery_processing_rule = processing_rules['aws']['vpcdnsquerylogs']
@@ -529,8 +264,7 @@ class testMSKLogs(unittest.TestCase):
     log_entry = '[2023-02-20 17:10:36,845] INFO App info kafka.consumer for consumer-consumer-lag-19 unregistered (org.apache.kafka.common.utils.AppInfoParser)'
 
     expected_attributes = {
-        'timestamp': '2023-02-20T17:10:36.845000',
-        'severity': 'INFO'
+        'timestamp': '2023-02-20T17:10:36.845000'
     }
 
     msk_processing_rule = processing_rules['aws']['msk']
@@ -662,9 +396,6 @@ class testAppFabricLogs(unittest.TestCase):
         }
         expected_attributes = {
             "timestamp": 1688429599000,
-            "log.source": "zendesk",
-            "audit.identity": "akua_mansa@example.com",
-            "audit.action": "Account Change: Update"
         }
 
         extracted_attributes = processing_rules['aws']['appfabric-ocsf-json'].get_extracted_log_attributes(log_entry)

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -15,6 +15,7 @@
 import unittest
 import os
 from log.processing import log_processing_rules
+from log.processing.processing import _resolve_aws_arn_from_pattern
 
 os.environ['LOG_FORWARDER_CONFIGURATION_LOCATION'] = 'local'
 os.environ['DEPLOYMENT_NAME'] = 'test'
@@ -33,6 +34,20 @@ network_firewall_key_name = 'random_prefix/AWSLogs/012345678910/network-firewall
 msk_key_name = 'AWSLogs/012345678910/KafkaBrokerLogs/us-east-1/demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20/2023-02-20-17/Broker-1_17-05_5b17f696.log.gz'
 global_accelerator_key_name = 'myprefix/AWSLogs/012345678910/globalaccelerator/us-west-2/2023/02/21/012345678910_globalaccelerator_f0154cf1-4ac0-451b-87a2-5b2ce89142e6_20230221T1305Z_2e13fabb.log.gz'
 appfabric_ocsf_json_key_name = 'my_random_prefix/AWSAppFabric/AuditLog/OCSF/JSON/JIRA/1b7374b9-3c6c-42da-8b09-1441a3c22fea/129c4667-01c8-47df-9af4-ed942bef13fe/20231123/AuditLog-1700743707323-7aae5b59-5fad-4d88-b387-9649474c5ffa'
+redshift_key_name = 'AWSLogs/123456789012/redshift/us-east-1/2013/10/29/123456789012_redshift_us-east-1_mycluster_userlog_2013-10-29T18:01.gz'
+
+alb_log_entry = 'http 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.000 0.001 0.000 200 200 34 366 "GET http://www.example.com:80/ HTTP/1.1" "curl/7.46.0" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337262-36d228ad5d99923122bbe354" "-" "-" 0 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
+classic_elb_log_entry = '2022-09-27T22:48:26.330387Z a2e8277e0e09143fbb06db5dcd2a14c2 3.67.7.163:8596 192.168.18.161:32728 0.000042 0.004504 0.000036 404 404 0 1086 "GET http://a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80/n9BxiYVakde9.php HTTP/1.1" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)" - -'
+nlb_log_entry = 'tls 2.0 2022-09-27T17:10:23 net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff f0f22c45225e4663 192.168.18.161:60808 192.168.103.168:443 24 16 140 518 - arn:aws:acm:us-east-1:012345678910:certificate/ae6e87cd-9848-465b-9433-b0d34850a685 - ECDHE-RSA-AES128-GCM-SHA256 tlsv12 - k8s-podinfo-frontend-352ef7564b-809b86b470cfa0ff.elb.us-east-1.amazonaws.com - - -'
+s3_access_log_entry = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be DOC-EXAMPLE-BUCKET1 [06/Feb/2019:00:00:38 +0000] 192.0.2.3 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE REST.GET.VERSIONING - "GET /DOC-EXAMPLE-BUCKET1?versioning HTTP/1.1" 200 - 113 - 7 - "-" "S3Console/0.4" - s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234= SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader DOC-EXAMPLE-BUCKET1.s3.us-west-1.amazonaws.com TLSV1.2 arn:aws:s3:us-west-1:123456789012:accesspoint/example-AP Yes'
+vpcdnsquery_log_entry = {
+    'version': '1.100000',
+    'account_id': '012345678910',
+    'region': 'us-east-1',
+    'vpc_id': 'vpc-0123456789abcdef12',
+    'query_timestamp': '2023-02-15T18:33:54Z',
+    'rcode': 'NOERROR'
+}
 
 class TestAWSAttributeInjection(unittest.TestCase):
     def test_cloudtrail_attributes(self):
@@ -207,6 +222,72 @@ class TestAWSAttributeInjection(unittest.TestCase):
     def test_appfabric_annotations_include_resource_type(self):
         annotations = processing_rules['aws']['appfabric-ocsf-json'].get_processing_log_annotations()
         self.assertEqual(annotations['aws.resource.type'], 'AWS::AppFabric::Ingestion')
+
+    def test_aws_arn_pattern_resolution_from_yaml_rules(self):
+        cases = {
+            'ALB': {
+                'key': alb_key_name,
+                'message': alb_log_entry,
+                'expected_arn': 'arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/app/my-loadbalancer/50dc6c495c0c9188'
+            },
+            'Classic-ELB': {
+                'key': classic_elb_key_name,
+                'message': classic_elb_log_entry,
+                'expected_arn': 'arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/a2e8277e0e09143fbb06db5dcd2a14c2'
+            },
+            'NLB': {
+                'key': nlb_key_name,
+                'message': nlb_log_entry,
+                'expected_arn': 'arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff'
+            },
+            'global-accelerator': {
+                'key': global_accelerator_key_name,
+                'message': '',
+                'expected_arn': 'arn:aws:globalaccelerator::012345678910:accelerator/f0154cf1-4ac0-451b-87a2-5b2ce89142e6'
+            },
+            'msk': {
+                'key': msk_key_name,
+                'message': '',
+                'expected_arn': 'arn:aws:kafka:us-east-1:012345678910:cluster/demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20'
+            },
+            'network-firewall': {
+                'key': network_firewall_key_name,
+                'message': {},
+                'expected_arn': 'arn:aws:network-firewall:us-east-1:012345678910:firewall/my-test-firewall'
+            },
+            'redshift': {
+                'key': redshift_key_name,
+                'message': '',
+                'expected_arn': 'arn:aws:redshift:us-east-1:123456789012:cluster:mycluster'
+            },
+            's3': {
+                'key': 'optional-prefix/2022-10-03-10-13-50-A211246203787B7F',
+                'message': s3_access_log_entry,
+                'expected_arn': 'arn:aws:s3:::DOC-EXAMPLE-BUCKET1'
+            },
+            'vpcdnsquerylogs': {
+                'key': 'OptionalPrefix/AWSLogs/012345678910/vpcdnsquerylogs/vpc-0123456789abcdf12/2023/02/15/vpc-0123456789abcdf12_vpcdnsquerylogs_012345678910_20230215T0000Z_213be99c.log.gz',
+                'message': vpcdnsquery_log_entry,
+                'expected_arn': 'arn:aws:ec2:us-east-1:012345678910:vpc/vpc-0123456789abcdef12'
+            },
+            'vpcflowlogs': {
+                'key': vpcflowlog_key_name,
+                'message': '',
+                'expected_arn': 'arn:aws:ec2:us-east-1:012345678910:vpc-flow-log/fl-07f38b767c7cd46e3'
+            }
+        }
+
+        for rule_name, case in cases.items():
+            with self.subTest(rule_name=rule_name):
+                rule = processing_rules['aws'][rule_name]
+                attributes = {}
+                attributes.update(rule.get_attributes_from_s3_key_name(case['key']))
+                attributes.update(rule.get_processing_log_annotations())
+                attributes.update(rule.get_extracted_log_attributes(case['message']))
+
+                _resolve_aws_arn_from_pattern(attributes)
+
+                self.assertEqual(attributes.get('aws.arn'), case['expected_arn'])
 
 class TestS3KeyMatchingExpression(unittest.TestCase):
 

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -24,7 +24,7 @@ processing_rules, _ = log_processing_rules.load()
 
 cloudtrail_key_name = 'random_prefix/AWSLogs/012345678910/CloudTrail/us-east-1/2022/09/23/012345678910_CloudTrail_us-east-1_20220923T2350Z_noxkMtWv70h0LEES.json.gz'
 cloudtrail_key_with_org_name = 'random_prefix/AWSLogs/o-012345678910/012345678910/CloudTrail/us-east-1/2022/09/23/012345678910_CloudTrail_us-east-1_20220923T2350Z_noxkMtWv70h0LEES.json.gz'
-alb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_app.k8s-podinfo-podinfoi-ffbc3dc280.82a34fae168ba1aa_20220721T1440Z_192.168.122.18_3okvlwdx.log.gz'
+alb_key_name = 'random1_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_app.k8s-podinfo-podinfoi-ffbc3dc280.82a34fae168ba1aa_20220721T1440Z_192.168.122.18_3okvlwdx.log.gz'
 classic_elb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_a2e8277e0e09143fbb06db5dcd2a14c2_20220730T2350Z_192.168.36.65_31av101p.log'
 nlb_key_name = 'random_prefix/AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_net.k8s-podinfo-frontend-352ef7564b.809b86b470cfa0ff_20220927T1715Z_bbb0861d.log.gz'
 waf_key_name = 'random_prefix/AWSLogs/012345678910/WAFLogs/eu-west-1/my-web-acl/2023/02/15/14/30/012345678910_waflogs_us-east-1_my-web-acl_20230215T1430Z_ec507835.log.gz'
@@ -39,6 +39,10 @@ redshift_key_name = 'AWSLogs/123456789012/redshift/us-east-1/2013/10/29/12345678
 alb_log_entry = 'http 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 192.168.131.39:2817 10.0.0.1:80 0.000 0.001 0.000 200 200 34 366 "GET http://www.example.com:80/ HTTP/1.1" "curl/7.46.0" - - arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 "Root=1-58337262-36d228ad5d99923122bbe354" "-" "-" 0 2018-07-02T22:22:48.364000Z "forward" "-" "-" "10.0.0.1:80" "200" "-" "-"'
 classic_elb_log_entry = '2022-09-27T22:48:26.330387Z a2e8277e0e09143fbb06db5dcd2a14c2 3.67.7.163:8596 192.168.18.161:32728 0.000042 0.004504 0.000036 404 404 0 1086 "GET http://a2e8277e0e09143fbb06db5dcd2a14c2-1086714162.us-east-1.elb.amazonaws.com:80/n9BxiYVakde9.php HTTP/1.1" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)" - -'
 nlb_log_entry = 'tls 2.0 2022-09-27T17:10:23 net/k8s-podinfo-frontend-352ef7564b/809b86b470cfa0ff f0f22c45225e4663 192.168.18.161:60808 192.168.103.168:443 24 16 140 518 - arn:aws:acm:us-east-1:012345678910:certificate/ae6e87cd-9848-465b-9433-b0d34850a685 - ECDHE-RSA-AES128-GCM-SHA256 tlsv12 - k8s-podinfo-frontend-352ef7564b-809b86b470cfa0ff.elb.us-east-1.amazonaws.com - - -'
+network_firewall_log_entry = {
+    'event_timestamp': '1602627001',
+    'firewall_name': 'my-test-firewall',
+}
 s3_access_log_entry = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be DOC-EXAMPLE-BUCKET1 [06/Feb/2019:00:00:38 +0000] 192.0.2.3 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be 3E57427F3EXAMPLE REST.GET.VERSIONING - "GET /DOC-EXAMPLE-BUCKET1?versioning HTTP/1.1" 200 - 113 - 7 - "-" "S3Console/0.4" - s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234= SigV4 ECDHE-RSA-AES128-GCM-SHA256 AuthHeader DOC-EXAMPLE-BUCKET1.s3.us-west-1.amazonaws.com TLSV1.2 arn:aws:s3:us-west-1:123456789012:accesspoint/example-AP Yes'
 vpcdnsquery_log_entry = {
     'version': '1.100000',
@@ -52,21 +56,14 @@ vpcdnsquery_log_entry = {
 class TestAWSAttributeInjection(unittest.TestCase):
     def test_cloudtrail_attributes(self):
         cloudtrail_processing_rule = processing_rules['aws']['CloudTrail']
-        expected_attributes = {
-                        'aws.account.id': '012345678910',
-                        'aws.region': 'us-east-1',
-                      }
+        expected_attributes = {}
 
         attributes = cloudtrail_processing_rule.get_attributes_from_s3_key_name(cloudtrail_key_name)
         self.assertEqual(attributes,expected_attributes)
 
     def test_cloudtrail_with_org_id_attributes(self):
         cloudtrail_processing_rule = processing_rules['aws']['CloudTrail']
-        expected_attributes = {
-            'aws.account.id': '012345678910',
-            'aws.region': 'us-east-1',
-            'aws.organization.id': 'o-012345678910'
-        }
+        expected_attributes = {}
 
         attributes = cloudtrail_processing_rule.get_attributes_from_s3_key_name(cloudtrail_key_with_org_name)
         self.assertEqual(attributes, expected_attributes)
@@ -75,7 +72,7 @@ class TestAWSAttributeInjection(unittest.TestCase):
         alb_processing_rule = processing_rules['aws']['ALB']
         expected_attributes = {
                         'aws.account.id': '012345678910',
-                        'aws.region': 'us-east-1'
+                        'aws.region': 'us-east-1',
                       }
 
         attributes = alb_processing_rule.get_attributes_from_s3_key_name(alb_key_name)
@@ -85,7 +82,7 @@ class TestAWSAttributeInjection(unittest.TestCase):
         classic_elb_processing_rule = processing_rules['aws']['Classic-ELB']
         expected_attributes = {
                         'aws.account.id': '012345678910',
-                        'aws.region': 'us-east-1'
+                        'aws.region': 'us-east-1',
                       }
 
         attributes = classic_elb_processing_rule.get_attributes_from_s3_key_name(classic_elb_key_name)
@@ -95,7 +92,7 @@ class TestAWSAttributeInjection(unittest.TestCase):
         nlb_processing_rule = processing_rules['aws']['NLB']
         expected_attributes = {
                         'aws.account.id': '012345678910',
-                        'aws.region': 'us-east-1'
+                        'aws.region': 'us-east-1',
                       }
 
         attributes = nlb_processing_rule.get_attributes_from_s3_key_name(nlb_key_name)
@@ -104,18 +101,14 @@ class TestAWSAttributeInjection(unittest.TestCase):
     def test_waf_attributes(self):
         waf_processing_rule = processing_rules['aws']['waf']
         attributes = waf_processing_rule.get_attributes_from_s3_key_name(waf_key_name)
-        expected_attributes = {
-                        'aws.account.id': '012345678910',
-                        'aws.region': 'eu-west-1',
-                        'aws.resource.id': 'my-web-acl'
-                      }
+        expected_attributes = {}
 
         self.assertEqual(attributes,expected_attributes)
 
     def test_cloudfront_attributes(self):
-        expected_attributes = {'aws.resource.id': 'E1SFLUZKKLSP61'}
         cloudfront_processing_rule = processing_rules['aws']['cloudfront']
         attributes = cloudfront_processing_rule.get_attributes_from_s3_key_name(cloudfront_key_name)
+        expected_attributes = {}
 
         self.assertEqual(attributes,expected_attributes)
 
@@ -133,10 +126,8 @@ class TestAWSAttributeInjection(unittest.TestCase):
 
     def test_networkfirewall_attributes(self):
         expected_attributes = {
-            'log.type': 'flow',
             'aws.account.id': '012345678910',
             'aws.region': 'us-east-1',
-            'aws.resource.id': 'my-test-firewall'
         }
 
         netfw_processing_rule = processing_rules['aws']['network-firewall']
@@ -149,7 +140,6 @@ class TestAWSAttributeInjection(unittest.TestCase):
             'aws.account.id': '012345678910',
             'aws.region': 'us-east-1',
             'aws.resource.id': 'demo-cluster-2-043b6d76-352c-494a-9eee-fbff5cc1687d-20',
-            'aws.msk.broker': 'Broker-1'
         }
 
         msk_processing_rule = processing_rules['aws']['msk']
@@ -159,7 +149,6 @@ class TestAWSAttributeInjection(unittest.TestCase):
     def test_global_accelerator_attributes(self):
         expected_attributes = {
             'aws.account.id': '012345678910',
-            'aws.region': 'us-west-2',
             'aws.resource.id': 'f0154cf1-4ac0-451b-87a2-5b2ce89142e6'
         }
 
@@ -252,7 +241,7 @@ class TestAWSAttributeInjection(unittest.TestCase):
             },
             'network-firewall': {
                 'key': network_firewall_key_name,
-                'message': {},
+                'message': network_firewall_log_entry,
                 'expected_arn': 'arn:aws:network-firewall:us-east-1:012345678910:firewall/my-test-firewall'
             },
             'redshift': {

--- a/tests/unit/log/processing/rules/test_attribute_injection.py
+++ b/tests/unit/log/processing/rules/test_attribute_injection.py
@@ -152,6 +152,62 @@ class TestAWSAttributeInjection(unittest.TestCase):
         attributes = global_accelerator_processing_rule.get_attributes_from_s3_key_name(global_accelerator_key_name)
         self.assertEqual(attributes,expected_attributes)
 
+    def test_alb_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['ALB'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::ElasticLoadBalancingV2::LoadBalancer')
+
+    def test_nlb_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['NLB'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::ElasticLoadBalancingV2::LoadBalancer')
+
+    def test_classic_elb_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['Classic-ELB'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::ElasticLoadBalancing::LoadBalancer')
+
+    def test_cloudtrail_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['CloudTrail'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::CloudTrail::Trail')
+
+    def test_cloudfront_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['cloudfront'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::CloudFront::Distribution')
+
+    def test_global_accelerator_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['global-accelerator'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::GlobalAccelerator::Accelerator')
+
+    def test_msk_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['msk'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::MSK::Cluster')
+
+    def test_network_firewall_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['network-firewall'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::NetworkFirewall::Firewall')
+
+    def test_redshift_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['redshift'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::Redshift::Cluster')
+
+    def test_s3_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['s3'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::S3::Bucket')
+
+    def test_vpcflowlogs_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['vpcflowlogs'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::EC2::VPC')
+
+    def test_vpcdnsquerylogs_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['vpcdnsquerylogs'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::EC2::VPC')
+
+    def test_waf_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['waf'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::WAFv2::WebACL')
+
+    def test_appfabric_annotations_include_resource_type(self):
+        annotations = processing_rules['aws']['appfabric-ocsf-json'].get_processing_log_annotations()
+        self.assertEqual(annotations['aws.resource.type'], 'AWS::AppFabric::Ingestion')
+
 class TestS3KeyMatchingExpression(unittest.TestCase):
 
     def test_cloudtrail_s3_key(self):

--- a/tests/unit/log/processing/rules/test_cwl_fh_s3_extraction.py
+++ b/tests/unit/log/processing/rules/test_cwl_fh_s3_extraction.py
@@ -34,7 +34,6 @@ class TestAttributeExtractionCWLFireHoseS3(unittest.TestCase):
         expected_attributes = {
             "timestamp": 1676419301941,
             "content": "Hello World!",
-            "aws.log_event_id": "37385399698484814707871715858877515407325547836143501312",
             "aws.service": "lambda",
             "aws.resource.id": "hello-world-123"
         }
@@ -55,7 +54,6 @@ class TestAttributeExtractionCWLFireHoseS3(unittest.TestCase):
         expected_attributes = {
             "timestamp": 1676419301941,
             "content": "Hello World!",
-            "aws.log_event_id": "37385399698484814707871715858877515407325547836143501312",
             "aws.service": "eks",
             "aws.resource.id": "my_cluster",
             "log.source": "placeholder"

--- a/tests/unit/log/processing/test_process_log_object.py
+++ b/tests/unit/log/processing/test_process_log_object.py
@@ -353,6 +353,44 @@ class TestProcessLogObject(unittest.TestCase):
         self.assertIn('cloud.log_forwarder', call_args)
 
     @patch('boto3._get_default_session')
+    def test_text_log_emits_aws_arn_from_pattern(self, mock_session):
+        from log.processing import log_processing_rules
+
+        test_data = (
+            'http 2018-07-02T22:23:00.186641Z app/my-loadbalancer/50dc6c495c0c9188 '
+            '192.168.131.39:2817 10.0.0.1:80 0.000 0.001 0.000 200 200 34 366 '
+            '"GET http://www.example.com:80/ HTTP/1.1" "curl/7.46.0" - - '
+            'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/my-targets/73e2d6bc24d8a067 '
+            '"Root=1-58337262-36d228ad5d99923122bbe354" "-" "-" 0 2018-07-02T22:22:48.364000Z '
+            '"forward" "-" "-" "10.0.0.1:80" "200" "-" "-"\n'
+        )
+
+        mock_s3_client = Mock()
+        mock_s3_client.get_object.return_value = self._create_s3_response(test_data, compressed=True)
+        mock_session_instance = Mock()
+        mock_session_instance.client.return_value = mock_s3_client
+        mock_session.return_value = mock_session_instance
+
+        processing_rules, _ = log_processing_rules.load()
+        log_rule = processing_rules['aws']['ALB']
+
+        process_log_object(
+            log_processing_rule=log_rule,
+            bucket='my-test-bucket',
+            key='AWSLogs/012345678910/elasticloadbalancing/us-east-1/2022/09/23/012345678910_elasticloadbalancing_us-east-1_app.my-loadbalancer.50dc6c495c0c9188_20220721T1440Z_192.168.122.18_3okvlwdx.log.gz',
+            bucket_region='us-west-2',
+            log_sinks=[self.mock_log_sink],
+            lambda_context=self.mock_lambda_context
+        )
+
+        call_args = self.mock_log_sink.push.call_args[0][0]
+        self.assertEqual(
+            call_args['aws.arn'],
+            'arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/app/my-loadbalancer/50dc6c495c0c9188'
+        )
+        self.assertNotIn('aws.arn.pattern', call_args)
+
+    @patch('boto3._get_default_session')
     def test_large_json_array(self, mock_session):
         """Test processing large JSON array to ensure streaming works"""
         # Create large test data (1000 entries)

--- a/tests/unit/log/processing/test_process_log_object.py
+++ b/tests/unit/log/processing/test_process_log_object.py
@@ -340,12 +340,16 @@ class TestProcessLogObject(unittest.TestCase):
             lambda_context=self.mock_lambda_context
         )
 
-        # Verify context attributes were added
+        # Verify context attributes were added (both old and new)
         call_args = self.mock_log_sink.push.call_args[0][0]
         self.assertIn('log.source.aws.s3.bucket.name', call_args)
         self.assertEqual(call_args['log.source.aws.s3.bucket.name'], 'my-test-bucket')
         self.assertIn('log.source.aws.s3.key.name', call_args)
         self.assertEqual(call_args['log.source.aws.s3.key.name'], 'logs/2024/01/01/test.json')
+        self.assertIn('dt.da.aws.s3.bucket.name', call_args)
+        self.assertEqual(call_args['dt.da.aws.s3.bucket.name'], 'my-test-bucket')
+        self.assertIn('dt.da.aws.s3.key.name', call_args)
+        self.assertEqual(call_args['dt.da.aws.s3.key.name'], 'logs/2024/01/01/test.json')
         self.assertIn('cloud.log_forwarder', call_args)
 
     @patch('boto3._get_default_session')

--- a/tests/unit/log/processing/test_process_log_object.py
+++ b/tests/unit/log/processing/test_process_log_object.py
@@ -348,6 +348,52 @@ class TestProcessLogObject(unittest.TestCase):
         self.assertEqual(call_args['dt.da.aws.s3.key.name'], 'logs/2024/01/01/test.json')
 
     @patch('boto3._get_default_session')
+    def test_output_reduced_fields_include_missing_keys_as_none(self, mock_session):
+        """Test that reduced output always includes allowed keys, defaulting missing ones to None."""
+        test_data = json.dumps([{"message": "test"}])
+
+        mock_s3_client = Mock()
+        mock_s3_client.get_object.return_value = self._create_s3_response(test_data)
+        mock_session_instance = Mock()
+        mock_session_instance.client.return_value = mock_s3_client
+        mock_session.return_value = mock_session_instance
+
+        log_rule = LogProcessingRule(
+            name='test_reduced_fields',
+            source='s3',
+            known_key_path_pattern='.*',
+            log_format='json',
+            log_entries_key=None,
+            annotations={},
+            attribute_extraction_jmespath_expression={}
+        )
+
+        process_log_object(
+            log_processing_rule=log_rule,
+            bucket='my-test-bucket',
+            key='logs/2024/01/01/test.json',
+            bucket_region='us-west-2',
+            log_sinks=[self.mock_log_sink],
+            lambda_context=self.mock_lambda_context
+        )
+
+        self.assertEqual(self.mock_log_sink.push.call_count, 1)
+        call_args = self.mock_log_sink.push.call_args[0][0]
+
+        expected_keys = {
+            'dt.da.aws.s3.bucket.name',
+            'dt.da.aws.s3.key.name',
+            'aws.arn',
+            'aws.resource.type',
+            'content',
+            'timestamp'
+        }
+        self.assertEqual(set(call_args.keys()), expected_keys)
+        self.assertIsNone(call_args['aws.arn'])
+        self.assertIsNone(call_args['aws.resource.type'])
+        self.assertIsNone(call_args['timestamp'])
+
+    @patch('boto3._get_default_session')
     def test_text_log_emits_aws_arn_from_pattern(self, mock_session):
         from log.processing import log_processing_rules
 

--- a/tests/unit/log/processing/test_process_log_object.py
+++ b/tests/unit/log/processing/test_process_log_object.py
@@ -342,15 +342,10 @@ class TestProcessLogObject(unittest.TestCase):
 
         # Verify context attributes were added (both old and new)
         call_args = self.mock_log_sink.push.call_args[0][0]
-        self.assertIn('log.source.aws.s3.bucket.name', call_args)
-        self.assertEqual(call_args['log.source.aws.s3.bucket.name'], 'my-test-bucket')
-        self.assertIn('log.source.aws.s3.key.name', call_args)
-        self.assertEqual(call_args['log.source.aws.s3.key.name'], 'logs/2024/01/01/test.json')
         self.assertIn('dt.da.aws.s3.bucket.name', call_args)
         self.assertEqual(call_args['dt.da.aws.s3.bucket.name'], 'my-test-bucket')
         self.assertIn('dt.da.aws.s3.key.name', call_args)
         self.assertEqual(call_args['dt.da.aws.s3.key.name'], 'logs/2024/01/01/test.json')
-        self.assertIn('cloud.log_forwarder', call_args)
 
     @patch('boto3._get_default_session')
     def test_text_log_emits_aws_arn_from_pattern(self, mock_session):


### PR DESCRIPTION
Reduce the amount of log processing done by the forwarder, after this changes the only attributes sent will be:

- 'dt.da.aws.s3.bucket.name'
- 'dt.da.aws.s3.key.name'
- 'aws.arn'
- 'aws.resource.type'
- 'content'
- 'timestamp'